### PR TITLE
fix require_nested ordering by putting Vm before Lpar and Vios

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -2,13 +2,13 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :EventTargetParser
-  require_nested :Lpar
   require_nested :MetricsCapture
   require_nested :MetricsCollectorWorker
   require_nested :Refresher
   require_nested :RefreshWorker
-  require_nested :Vios
   require_nested :Vm
+  require_nested :Lpar
+  require_nested :Vios
 
   def self.params_for_create
     @params_for_create ||= {


### PR DESCRIPTION
Without that change, I am getting this error in evm.log:

```
[----] I, [2021-10-12T09:12:55.736483 #3206384:16a44]  INFO -- evm: EMS: [coophmc2], id: [3] Saving EMS Inventory...
[----] E, [2021-10-12T09:12:55.752377 #3206384:16a44] ERROR -- evm: Error when saving InventoryCollection:<ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm>, blacklist: [genealogy_parent, parent, resource_pool], strategy: local_db_find_missing_references with strategy: local_db_find_missing_references, saver_strategy: default, targeted: true. Message: ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar is not a subclass of ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm
```