### PR TITLE
add the ability to rename a vm

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm
+  supports :rename
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.lpar(ems_ref)
@@ -18,6 +20,15 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers
       connection.poweroff_lpar(ems_ref, params)
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("error powering off LPAR #{ems_ref} with params=#{params}: #{e}")
+      raise
+    end
+  end
+
+  def raw_rename(new_name)
+    ext_management_system.with_provider_connection do |connection|
+      connection.rename_lpar(ems_ref, new_name)
+    rescue IbmPowerHmc::Connection::HttpError => e
+      $ibm_power_hmc_log.error("error renaming LPAR #{ems_ref} to #{new_name}: #{e}")
       raise
     end
   end


### PR DESCRIPTION
Add the ability to rename logical partitions (not virtual I/O servers yet).
Depends on https://github.com/IBM/ibm_power_hmc_sdk_ruby/pull/25