### PR TITLE
use more accurate vm states

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -39,14 +39,14 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
     "not available"        => "unknown",
     "open firmware"        => "on",
     "running"              => "on",
-    "shutting down"        => "on",
-    "starting"             => "on",
-    "migrating not active" => "on",
+    "shutting down"        => "powering_down",
+    "starting"             => "powering_up",
+    "migrating not active" => "off",
     "migrating running"    => "on",
-    "hardware discovery"   => "unknown",
-    "suspended"            => "unknown",
-    "suspending"           => "unknown",
-    "resuming"             => "unknown",
+    "hardware discovery"   => "powering_up",
+    "suspended"            => "suspended",
+    "suspending"           => "suspended",
+    "resuming"             => "powering_up",
     "Unknown"              => "unknown"
   }.freeze
 


### PR DESCRIPTION
Report VM states more accurately, using the normalized values listed in https://github.com/ManageIQ/manageiq-graphql/blob/0c8711d7ace0cea63ba2d0100113612357c75a78/lib/manageiq/graphql/types/vm.rb#L24.