### PR TITLE
[WIP] retrieve cpu_speed for hosts

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -6,6 +6,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   def collect!
     $ibm_power_hmc_log.info("#{self.class}##{__method__}")
     manager.with_provider_connection do |connection|
+      @hmc = connection.management_console
+
       @cecs = connection.managed_systems
 
       @lpars = @cecs.map do |sys|
@@ -21,6 +23,14 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
         $ibm_power_hmc_log.error("vioses query failed for #{sys.uuid} #{e}")
         nil
       end.flatten.compact
+
+      @cpu_freqs = {}
+      @cecs.each do |sys|
+        freq = cpu_freq(connection, sys)
+        @cpu_freqs[sys.uuid] = freq unless freq.nil?
+      rescue => e
+        $ibm_power_hmc_log.error("cpu freq query failed for #{sys.uuid}: #{e}")
+      end
 
       $ibm_power_hmc_log.info("end collection")
     rescue IbmPowerHmc::Connection::HttpError => e
@@ -38,5 +48,25 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
 
   def vioses
     @vioses || []
+  end
+
+  def cpu_freqs
+    @cpu_freqs || {}
+  end
+
+  def cpu_freq(connection, sys)
+    # Retrieve the CPU frequency from one of the VIOSes with RMC active.
+    vios = vioses.select { |vios| vios.sys_uuid == sys.uuid && vios.rmc_state == "active" }.first
+    return if vios.nil?
+
+    cmd = "lsdev -dev proc0 -attr frequency"
+    job = connection.cli_run(@hmc.uuid, "viosvrcmd -m \"#{sys.name}\" -p \"#{vios.name}\" -c \"#{cmd}\"")
+    ret = job.results["returnCode"]&.to_i
+    return if ret != 0
+
+    result = job.results["result"]
+    return if result.nil?
+
+    result.split("\n").last.to_f / 1000000.0
   end
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -45,7 +45,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
       $ibm_power_hmc_log.error("managed systems query failed: #{e}")
       []
     end
-  
+
     @cpu_freqs = {}
     @cecs.each do |sys|
       freq = cpu_freq(connection, sys)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     return if vios.nil?
 
     vioscmd = "lsdev -dev proc0 -attr frequency"
-    cmd = %Q[viosvrcmd -m "#{sys.name}" -p "#{vios.name}" -c "#{vioscmd}"]
+    cmd = %(viosvrcmd -m "#{sys.name}" -p "#{vios.name}" -c "#{vioscmd}")
     job = connection.cli_run(@hmc.uuid, cmd)
     ret = job.results["returnCode"]&.to_i
     return if ret != 0

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -67,6 +67,6 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     result = job.results["result"]
     return if result.nil?
 
-    result.split("\n").last.to_f / 1000000.0
+    result.split("\n").last.to_f / 1_000_000.0
   end
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
 
   def cpu_freq(connection, sys)
     # Retrieve the CPU frequency from one of the VIOSes with RMC active.
-    vios = vioses.select { |vios| vios.sys_uuid == sys.uuid && vios.rmc_state == "active" }.first
+    vios = vioses.find { |v| v.sys_uuid == sys.uuid && v.rmc_state == "active" }
     return if vios.nil?
 
     cmd = "lsdev -dev proc0 -attr frequency"

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -59,8 +59,9 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     vios = vioses.find { |v| v.sys_uuid == sys.uuid && v.rmc_state == "active" }
     return if vios.nil?
 
-    cmd = "lsdev -dev proc0 -attr frequency"
-    job = connection.cli_run(@hmc.uuid, "viosvrcmd -m \"#{sys.name}\" -p \"#{vios.name}\" -c \"#{cmd}\"")
+    vioscmd = "lsdev -dev proc0 -attr frequency"
+    cmd = %Q[viosvrcmd -m "#{sys.name}" -p "#{vios.name}" -c "#{vioscmd}"]
+    job = connection.cli_run(@hmc.uuid, cmd)
     ret = job.results["returnCode"]&.to_i
     return if ret != 0
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -40,7 +40,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :bitness         => 64,
       :manufacturer    => "IBM",
       :model           => "#{sys.mtype}#{sys.model}",
-      # :cpu_speed     => 2348, # in MHz
+      :cpu_speed       => collector.cpu_freqs[sys.uuid],
       :memory_mb       => sys.memory,
       :cpu_total_cores => sys.cpus,
       :serial_number   => sys.serial


### PR DESCRIPTION
Not sure if we want this.
This seems quite a bit silly to go to these lengths just to get the cpu frequency, but it does not appear to be anywhere in the XML documents returned by the HMC.
I believe you can get it through PCM REST API but PCM is not enabled by default on most managed systems and comes at a cost.
I don't see it reported in the HMC UI either.
Wondering where PowerVC gets it from, but it is displayed in the PowerVC UI:

![image](https://user-images.githubusercontent.com/48122102/137506267-d44e5471-eb78-4e36-98f1-736434147eaa.png)

In MIQ, with these changes, it shows as:

![image](https://user-images.githubusercontent.com/48122102/137506998-6c729ce1-4131-4449-86de-93ebe2a8b3ba.png)