### PR TITLE
Do not run yamllint on VCR cassettes

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,7 @@
 ignore: |
   /vendor/**
   /spec/manageiq/**
+  /spec/vcr_cassettes/**
 
 extends: relaxed
 


### PR DESCRIPTION
Fixing per discussion with @vfebvre in https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/18#issuecomment-951996089