### PR TITLE
Add templates

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
@@ -6,7 +6,7 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser
       :ems_ref    => event.id,
       :timestamp  => event.published,
       # Serialize IbmPowerHmc::Event
-      :full_data  => {:data => event.data, :detail => event.detail},
+      :full_data  => {:data => event.data, :detail => event.detail, :usertask => event.usertask},
       :ems_id     => ems_id
     }
 

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -50,11 +50,11 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       case usertask["key"]
       when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_PARTITION_SAVE_AS", "TEMPLATE_PARTITION_CAPTURE"
         $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{event_uuid} #{usertask['key']} uuid #{usertask['template_uuid']} name #{usertask['labelParams'].first}")
-        target_collection.add_target(:association => :templates, :manager_ref => {:ems_ref => usertask['template_uuid']})
+        target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => usertask['template_uuid']})
       when "TEMPLATE_DELETE"
         template = ManageIQ::Providers::InfraManager::Template.find_by(:ems_id => ems_event.ext_management_system.id, :name => usertask['labelParams'])
         $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{event_uuid} #{usertask['key']} uuid #{template.uid_ems} name #{template.name}")
-        target_collection.add_target(:association => :templates, :manager_ref => {:ems_ref => template.uid_ems})
+        target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => template.uid_ems})
       end
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -37,10 +37,16 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
         $ibm_power_hmc_log.info("#{self.class}##{__method__} VirtualNetwork uuid #{uuid}")
         target_collection.add_target(:association => :hosts, :manager_ref => {:ems_ref => elems[-3]})
       when "UserTask"
-        case raw_event[:usertask]["key"]
-        when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_DELETE"
-          $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{uuid} #{raw_event[:usertask]['key']}")
-          # TODO: trigger refresh for all templates
+        if raw_event[:usertask]["status"].eql?("Completed")
+          case raw_event[:usertask]["key"]
+          when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_PARTITION_SAVE_AS", "TEMPLATE_PARTITION_CAPTURE"
+            $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{uuid} #{raw_event[:usertask]['key']} uuid #{raw_event[:usertask]['template_uuid']} name #{raw_event[:usertask]['labelParams'].first}")
+            target_collection.add_target(:association => :templates, :manager_ref => {:ems_ref => raw_event[:usertask]['template_uuid']})
+          when "TEMPLATE_DELETE"
+            template = ManageIQ::Providers::InfraManager::Template.find_by(:name => raw_event[:usertask]['labelParams'])
+            $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{uuid} #{raw_event[:usertask]['key']} uuid #{template.uid_ems} name #{template.name}")
+            target_collection.add_target(:association => :templates, :manager_ref => {:ems_ref => template.uid_ems})
+          end
         end
       end
     end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -53,8 +53,10 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
         target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => usertask['template_uuid']})
       when "TEMPLATE_DELETE"
         template = ManageIQ::Providers::InfraManager::Template.find_by(:ems_id => ems_event.ext_management_system.id, :name => usertask['labelParams'])
-        $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{event_uuid} #{usertask['key']} uuid #{template.uid_ems} name #{template.name}")
-        target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => template.uid_ems})
+        unless template.nil?
+          $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{event_uuid} #{usertask['key']} uuid #{template.uid_ems} name #{template.name}")
+          target_collection.add_target(:association => :miq_templates, :manager_ref => {:ems_ref => template.uid_ems})
+        end
       end
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -36,6 +36,9 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       when "VirtualNetwork"
         $ibm_power_hmc_log.info("#{self.class}##{__method__} VirtualNetwork uuid #{uuid}")
         target_collection.add_target(:association => :hosts, :manager_ref => {:ems_ref => elems[-3]})
+      when "UserTask"
+        $ibm_power_hmc_log.error("#{self.class}##{__method__} usertask uuid #{uuid} #{raw_event[:usertask]["key"]}")
+        #target_collection.process_usertask(raw_event[:test])
       end
     end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -58,5 +58,4 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       end
     end
   end
-
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -37,8 +37,11 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
         $ibm_power_hmc_log.info("#{self.class}##{__method__} VirtualNetwork uuid #{uuid}")
         target_collection.add_target(:association => :hosts, :manager_ref => {:ems_ref => elems[-3]})
       when "UserTask"
-        $ibm_power_hmc_log.error("#{self.class}##{__method__} usertask uuid #{uuid} #{raw_event[:usertask]["key"]}")
-        #target_collection.process_usertask(raw_event[:test])
+        case raw_event[:usertask]["key"]
+        when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_DELETE"
+          $ibm_power_hmc_log.info("#{self.class}##{__method__} usertask uuid #{uuid} #{raw_event[:usertask]['key']}")
+          # TODO: trigger refresh for all templates
+        end
       end
     end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
       do_vioses(connection)
       do_vswitches(connection)
       do_vlans(connection)
+      do_templates(connection)
       $ibm_power_hmc_log.info("end collection")
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("managed systems query failed: #{e}")
@@ -140,5 +141,16 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("vnic query failed for #{lpar.uuid}/#{vnic_dedicated_uuid}: #{e}")
     end
+  end
+
+  def do_templates(connection)
+    @templates = connection.templates_summary.map do |template|
+      connection.template(template.uuid)
+    rescue IbmPowerHmc::Connection::HttpError => e
+      $ibm_power_hmc_log.error("template query failed for #{template.uuid} #{e}")
+      nil
+    end.compact
+  rescue IbmPowerHmc::Connection::HttpError => e
+    $ibm_power_hmc_log.error("template query failed #{e}")
   end
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -52,6 +52,10 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   def vnics
     @vnics || {}
   end
+  
+  def templates
+    @templates || []
+  end
 
   private
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -57,6 +57,10 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     @templates || []
   end
 
+  def templates
+    @templates || []
+  end
+
   private
 
   # Get all vlans from all managed systems(cecs)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -52,7 +52,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   def vnics
     @vnics || {}
   end
-  
+
   def templates
     @templates || []
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -57,10 +57,6 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     @templates || []
   end
 
-  def templates
-    @templates || []
-  end
-
   private
 
   # Get all vlans from all managed systems(cecs)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -67,6 +67,18 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
     @vioses || []
   end
 
+  def templates
+    $ibm_power_hmc_log.info("#{self.class}##{__method__}")
+    manager.with_provider_connection do |connection|
+      @templates ||= references(:templates).map do |ems_ref|
+        connection.template(ems_ref)
+      rescue IbmPowerHmc::Connection::HttpError => e
+        $ibm_power_hmc_log.error("template query failed for #{template.uuid} #{e}")
+        nil
+      end.compact
+    end
+  end
+
   def netadapters
     @netadapters || {}
   end
@@ -102,6 +114,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
         add_target(:host_virtual_switches, target.ems_ref)
       when Lan
         add_target(:lans, target.ems_ref)
+      when ManageIQ::Providers::InfraManager::Template
+        add_target(:templates, target.ems_ref)
       else
         $ibm_power_hmc_log.info("#{self.class}##{__method__} WHAT IS THE CLASS NAME ? #{target.class.name} ")
       end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
   def templates
     $ibm_power_hmc_log.info("#{self.class}##{__method__}")
     manager.with_provider_connection do |connection|
-      @templates ||= references(:templates).map do |ems_ref|
+      @templates ||= references(:miq_templates).map do |ems_ref|
         connection.template(ems_ref)
       rescue IbmPowerHmc::Connection::HttpError => e
         $ibm_power_hmc_log.error("template query failed for #{ems_ref}: #{e}") unless e.status == 404
@@ -116,7 +116,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
       when Lan
         add_target(:lans, target.ems_ref)
       when ManageIQ::Providers::InfraManager::Template
-        add_target(:templates, target.ems_ref)
+        add_target(:miq_templates, target.ems_ref)
       else
         $ibm_power_hmc_log.info("#{self.class}##{__method__} WHAT IS THE CLASS NAME ? #{target.class.name} ")
       end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -73,10 +73,11 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
       @templates ||= references(:templates).map do |ems_ref|
         connection.template(ems_ref)
       rescue IbmPowerHmc::Connection::HttpError => e
-        $ibm_power_hmc_log.error("template query failed for #{template.uuid} #{e}")
+        $ibm_power_hmc_log.error("template query failed for #{ems_ref}: #{e}") unless e.status == 404
         nil
       end.compact
     end
+    @templates || []
   end
 
   def netadapters

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -181,15 +181,18 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
 
   def parse_templates
     collector.templates.each do |template|
-      persister.miq_templates.build(
+      t = persister.miq_templates.build(
         :uid_ems             => template.uuid,
         :ems_ref             => template.uuid,
         :name                => template.name,
+        :description         => template.description,
         :vendor              => "ibm_power_vm",
         :template            => true,
         :location            => "unknown",
         :raw_power_state     => "never"
       )
+      parse_vm_hardware(t, template)
+      parse_vm_operating_system(t, template)
     end
   end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     parse_cecs
     parse_lpars
     parse_vioses
+    parse_templates
   end
 
   def parse_cecs
@@ -176,6 +177,20 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :value        => lpar.ref_code,
       :read_only    => true
     )
+  end
+
+  def parse_templates
+    collector.templates.each do |template|
+      persister.miq_templates.build(
+        :uid_ems             => template.uuid,
+        :ems_ref             => template.uuid,
+        :name                => template.name,
+        :vendor              => "ibm_power_vm",
+        :template            => true,
+        :location            => "unknown",
+        :raw_power_state     => "never"
+      )
+    end
   end
 
   def lookup_power_state(state)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -182,14 +182,14 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   def parse_templates
     collector.templates.each do |template|
       t = persister.miq_templates.build(
-        :uid_ems             => template.uuid,
-        :ems_ref             => template.uuid,
-        :name                => template.name,
-        :description         => template.description,
-        :vendor              => "ibm_power_vm",
-        :template            => true,
-        :location            => "unknown",
-        :raw_power_state     => "never"
+        :uid_ems         => template.uuid,
+        :ems_ref         => template.uuid,
+        :name            => template.name,
+        :description     => template.description,
+        :vendor          => "ibm_power_vm",
+        :template        => true,
+        :location        => "unknown",
+        :raw_power_state => "never"
       )
       parse_vm_hardware(t, template)
       parse_vm_operating_system(t, template)

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.7"
+  spec.add_dependency "ibm_power_hmc", "~> 0.8"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
This adds HMC partition templates to the inventory. So far it only records memory and operating system information.
Event-based targeted refresh not functional at this time.