### PR TITLE
Add Host Ethernet Adapter Logical Ports to inventory

### DIFF
--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.6"
+  spec.add_dependency "ibm_power_hmc", "~> 0.7"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
Another type of ethernet adapters.
These do not have UUIDs so we use the MAC address as the unique ID instead.