### PR TITLE
[WIP] SharedStoragePool inventory

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
@@ -21,11 +21,11 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Stream
     @ems.with_provider_connection do |connection|
       catch(:stop_polling) do
         loop do
-          connection.next_events(false).each do |event|
+          connection.next_events.each do |event|
             throw :stop_polling if @stop_polling
             yield event
           end
-          sleep @poll_sleep
+          # sleep @poll_sleep
         end
       rescue => exception
         raise ProviderUnreachable, exception.message

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
@@ -37,6 +37,8 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser
           event_hash[:host_ems_ref] = elems[-3]
         end
       end
+      when "Cluster"
+        event_hash[:storage_ems_ref] = uuid
     end
 
     event_hash

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
@@ -36,9 +36,9 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser
         if elems.length >= 4 && elems[-4] == "ManagedSystem"
           event_hash[:host_ems_ref] = elems[-3]
         end
-      end
       when "Cluster"
         event_hash[:storage_ems_ref] = uuid
+      end
     end
 
     event_hash

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -36,6 +36,9 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       when "VirtualNetwork"
         $ibm_power_hmc_log.info("#{self.class}##{__method__} VirtualNetwork uuid #{uuid}")
         target_collection.add_target(:association => :hosts, :manager_ref => {:ems_ref => elems[-3]})
+      when "Cluster"
+        $ibm_power_hmc_log.info("#{self.class}##{__method__} Cluster uuid #{uuid}")
+        target_collection.add_target(:association => :storages, :manager_ref => {:ems_ref => elems.last})
       end
     end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -56,10 +56,9 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
 
   attr_accessor :ssps
 
-
   def ssp_lus_by_udid
     @ssp_lus_by_udid ||= {}
-    ssps.each { |ssp| ssp.lus.each { |lu| @ssp_lus_by_udid[lu.udid] = ssp.cluster_uuid }}
+    ssps.each { |ssp| ssp.lus.each { |lu| @ssp_lus_by_udid[lu.udid] = ssp.cluster_uuid } }
     @ssp_lus_by_udid
   end
 
@@ -70,7 +69,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   def vscsi_lun_mappings_by_uuid
     @vscsi_lun_mappings_by_uuid ||= vscsi_lun_mappings.group_by(&:lpar_uuid)
   end
-  
+
   private
 
   def do_ssps(connection)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -58,7 +58,9 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
 
 
   def ssp_lus_by_udid
-    @ssp_lus_by_udid ||= ssps.flat_map(&:lus).index_by(&:udid)
+    @ssp_lus_by_udid ||= {}
+    ssps.each { |ssp| ssp.lus.each { |lu| @ssp_lus_by_udid[lu.udid] = ssp.uuid }}
+    @ssp_lus_by_udid
   end
 
   def vscsi_lun_mappings

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     @netadapters = {}
     @sriov_elps = {}
     @vnics = {}
+    @ssps = {}
   end
 
   def collect!
@@ -14,6 +15,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
       do_vioses(connection)
       do_vswitches(connection)
       do_vlans(connection)
+      do_ssps(connection)
       $ibm_power_hmc_log.info("end collection")
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("managed systems query failed: #{e}")
@@ -52,7 +54,15 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     @vnics || {}
   end
 
+  attr_accessor :ssps
+
   private
+
+  def do_ssps(connection)
+    @ssps = connection.ssps
+    rescue IbmPowerHmc::Connection::HttpError => e
+      $ibm_power_hmc_log.error("ssps query failed : #{e}")
+  end
 
   # Get all vlans from all managed systems(cecs)
   def do_vlans(connection)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -59,7 +59,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
 
   def ssp_lus_by_udid
     @ssp_lus_by_udid ||= {}
-    ssps.each { |ssp| ssp.lus.each { |lu| @ssp_lus_by_udid[lu.udid] = ssp.uuid }}
+    ssps.each { |ssp| ssp.lus.each { |lu| @ssp_lus_by_udid[lu.udid] = ssp.cluster_uuid }}
     @ssp_lus_by_udid
   end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -56,6 +56,19 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
 
   attr_accessor :ssps
 
+
+  def ssp_lus_by_udid
+    @ssp_lus_by_udid ||= ssps.flat_map(&:lus).index_by(&:udid)
+  end
+
+  def vscsi_lun_mappings
+    @vscsi_lun_mappings ||= vioses.flat_map { |vios| vios.vscsi_mappings.select { |mapping| mapping.storage.kind_of?(IbmPowerHmc::LogicalUnit) } }
+  end
+
+  def vscsi_lun_mappings_by_uuid
+    @vscsi_lun_mappings_by_uuid ||= vscsi_lun_mappings.group_by(&:lpar_uuid)
+  end
+  
   private
 
   def do_ssps(connection)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -70,11 +70,12 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
   def ssps
     $ibm_power_hmc_log.info("#{self.class}##{__method__}")
     manager.with_provider_connection do |connection|
-      @ssps ||= connection.ssps() # we gather every ssp.
+      @ssps = connection.ssps() # we gather every ssp.
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("error querying ssps  #{ems_ref}: #{e}") unless e.status == 404
       nil
-    end.compact
+    end
+    @ssps || []
   end
 
   def netadapters

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -102,8 +102,6 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
         add_target(:host_virtual_switches, target.ems_ref)
       when Lan
         add_target(:lans, target.ems_ref)
-      else
-        $ibm_power_hmc_log.info("#{self.class}##{__method__} WHAT IS THE CLASS NAME ? #{target.class.name} ")
       end
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -67,6 +67,16 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
     @vioses || []
   end
 
+  def ssps
+    $ibm_power_hmc_log.info("#{self.class}##{__method__}")
+    manager.with_provider_connection do |connection|
+      @ssps ||= connection.ssps() # we gather every ssp.
+    rescue IbmPowerHmc::Connection::HttpError => e
+      $ibm_power_hmc_log.error("error querying ssps  #{ems_ref}: #{e}") unless e.status == 404
+      nil
+    end.compact
+  end
+
   def netadapters
     @netadapters || {}
   end
@@ -102,6 +112,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
         add_target(:host_virtual_switches, target.ems_ref)
       when Lan
         add_target(:lans, target.ems_ref)
+      when Storage
+        add_target(:storages, target.ems_ref)
       end
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -70,7 +70,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
   def ssps
     $ibm_power_hmc_log.info("#{self.class}##{__method__}")
     manager.with_provider_connection do |connection|
-      @ssps = connection.ssps() # we gather every ssp.
+      @ssps = connection.ssps # we gather every ssp.
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("error querying ssps  #{ems_ref}: #{e}") unless e.status == 404
       nil

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -35,7 +35,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
         :name        => ssp.name,
         :total_space => ssp.capacity.to_f.gigabytes.round, # hmc returns a str in byte
         :ems_ref     => ssp.cluster_uuid,
-        :free_space  => ssp.free_space.to_f.gigabytes.round 
+        :free_space  => ssp.free_space.to_f.gigabytes.round
       )
     end
   end
@@ -45,11 +45,11 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       found_ssp_uuid = collector.ssp_lus_by_udid[mapping.storage.udid]
 
       persister.disks.build(
-        :device_type     => "disk",
-        :hardware        => hardware,
-        :storage         => persister.storages.lazy_find(found_ssp_uuid),
-        :device_name     => mapping.storage.name,
-        :size            => mapping.storage.capacity.to_f.gigabytes.round
+        :device_type => "disk",
+        :hardware    => hardware,
+        :storage     => persister.storages.lazy_find(found_ssp_uuid),
+        :device_name => mapping.storage.name,
+        :size        => mapping.storage.capacity.to_f.gigabytes.round
       )
     end
   end
@@ -115,7 +115,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :host            => host
     )
     hardware = parse_vm_hardware(vm, lpar)
-    
+ 
     if type.eql?(ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar.name)
       parse_lpar_guest_devices(lpar, hardware)
     end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -6,6 +6,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     parse_cecs
     parse_lpars
     parse_vioses
+    parse_ssps
   end
 
   def parse_cecs
@@ -24,6 +25,17 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       parse_host_hardware(host, sys)
       parse_vswitches(host, sys)
       parse_vlans(sys)
+    end
+  end
+
+  def parse_ssps
+    collector.ssps.each do |ssp|
+      storage = persister.storages.build(
+        :name        => ssp.name,
+        :total_space => ssp.capacity.to_f.gigabytes.round, # hmc returns a str in byte
+        :ems_ref     => ssp.uuid,
+        :free_space  => ssp.free_space.to_f.gigabytes.round
+      )
     end
   end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -29,11 +29,12 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   end
 
   def parse_ssps
+    $ibm_power_hmc_log.info("#{self.class}##{__method__}")
     collector.ssps.each do |ssp|
       storage = persister.storages.build(
         :name        => ssp.name,
         :total_space => ssp.capacity.to_f.gigabytes.round, # hmc returns a str in byte
-        :ems_ref     => ssp.uuid,
+        :ems_ref     => ssp.cluster_uuid,
         :free_space  => ssp.free_space.to_f.gigabytes.round 
       )
     end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -29,7 +29,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   end
 
   def parse_ssps
-    $ibm_power_hmc_log.info("#{self.class}##{__method__}")
+    $ibm_power_hmc_log.info("#{self.class}##{__method__} : received ssps => #{collector.ssps}")
     collector.ssps.each do |ssp|
       storage = persister.storages.build(
         :name        => ssp.name,

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -40,29 +40,13 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   end
 
   def parse_vm_disks(lpar, hardware)
-    lpar_lu_mappings = collector.vioses.flat_map do |vios|
-      vios.vscsi_mappings.select do |mapping|
-        mapping.lpar_uuid == lpar.uuid && mapping.storage.kind_of?(IbmPowerHmc::LogicalUnit)
-      end
-    end
-
-    lpar_lu_mappings.each do |mapping|
-      found_ssp = nil
-      collector.ssps.each do |ssp|
-        lu = ssp.lus.find do |lu|
-          lu.udid == mapping.storage.udid
-        end
-        unless lu.nil?
-          found_ssp = ssp
-          break
-        end
-      end
-
-      $ibm_power_hmc_log.info("#{self.class}##{__method__} : found_ssp : #{found_ssp}")
-
+    collector.vscsi_lun_mappings_by_uuid[lpar.uuid].to_a.each do |mapping|
+      found_ssp = collector.ssp_lus_by_udid[mapping.storage.udid]
+      
       persister.disks.build(
         :hardware    => hardware,
         :device_type => "disk",
+        :storage     => persister.storages.lazy_find(found_ssp),
         :device_name => mapping.storage.name,
         :size        => mapping.storage.capacity.to_f.gigabytes.round
       )
@@ -105,7 +89,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   def parse_lpars
     collector.lpars.each do |lpar|
       vm = parse_lpar_common(lpar, ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar.name)
-      parse_lpar_guest_devices(lpar, vm)
+      # parse_lpar_guest_devices(lpar, vm)
     end
   end
 
@@ -131,6 +115,11 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :host            => host
     )
     hardware = parse_vm_hardware(vm, lpar)
+    
+    if type.eql?(ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar.name)
+      parse_lpar_guest_devices(lpar, vm, hardware)
+    end
+
     parse_vm_operating_system(vm, lpar)
     parse_vm_guest_devices(lpar, hardware)
     parse_vm_advanced_settings(vm, lpar)
@@ -193,8 +182,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     end
   end
 
-  def parse_lpar_guest_devices(lpar, vm)
-    hardware ||= persister.hardwares.lazy_find(:vm_or_template => vm)
+  def parse_lpar_guest_devices(lpar, vm, hardware)
+    # hardware ||= persister.hardwares.lazy_find(:vm_or_template => vm)
     lpar.vnic_dedicated_uuids.map do |uuid|
       build_ethernet_dev(collector.vnics[uuid], hardware, "vnic")
     end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -12,6 +12,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :guest_devices)
     add_collection(infra, :lans)
     add_collection(infra, :host_virtual_lans)
+    add_collection(infra, :storages)
     add_collection(infra, :vms_and_templates_advanced_settings) do |builder|
       builder.add_properties(
         :manager_ref                  => %i[resource name],

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -13,6 +13,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :lans)
     add_collection(infra, :host_virtual_lans)
     add_collection(infra, :storages)
+    add_collection(infra, :disks)
     add_collection(infra, :vms_and_templates_advanced_settings) do |builder|
       builder.add_properties(
         :manager_ref                  => %i[resource name],

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.7"
+  spec.add_dependency "ibm_power_hmc", "~> 0.8"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
SSPs are inserted inside `storages` table in the MIQ model.

For now, only the global refresh works. This means that _ssps_ are inserted at the MIQ startup.
![image](https://user-images.githubusercontent.com/70648532/144854951-cb0a5a1f-1d45-4d83-98b5-b477e954ef59.png)
