### PR TITLE
Fix Templates not subclassed under IbmPowerHmc

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -9,6 +9,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   require_nested :ProvisionWorkflow
   require_nested :Refresher
   require_nested :RefreshWorker
+  require_nested :Template
   require_nested :Vm
   require_nested :Lpar
   require_nested :Vios

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmPowerHmc::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
+end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -115,7 +115,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
         add_target!(:host_virtual_switches, target.ems_ref)
       when Lan
         add_target!(:lans, target.ems_ref)
-      when ManageIQ::Providers::InfraManager::Template
+      when ManageIQ::Providers::IbmPowerHmc::InfraManager::Template
         add_target!(:miq_templates, target.ems_ref)
       else
         $ibm_power_hmc_log.info("#{self.class}##{__method__} WHAT IS THE CLASS NAME ? #{target.class.name} ")


### PR DESCRIPTION
These were being created as `ManageIQ::Providers::InfraManager::Template` types