### PR TITLE
Fix vendor references

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -111,7 +111,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :name            => lpar.name,
       :location        => "unknown",
       :description     => lpar.type,
-      :vendor          => "ibm_power_vm",
+      :vendor          => "ibm_power_hmc",
       :raw_power_state => lpar.state,
       :host            => host
     )
@@ -216,7 +216,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
         :ems_ref         => template.uuid,
         :name            => template.name,
         :description     => template.description,
-        :vendor          => "ibm_power_vm",
+        :vendor          => "ibm_power_hmc",
         :template        => true,
         :location        => "unknown",
         :raw_power_state => "never"

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -59,7 +59,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
         :uid_ems         => '12345678',
         :ems_ref         => '12345678',
         :name            => "supertest",
-        :vendor          => "ibm_power_vm",
+        :vendor          => "ibm_power_hmc",
         :template        => true,
         :location        => "unknown",
         :raw_power_state => "never",


### PR DESCRIPTION
Use "ibm_power_hmc" vendor name to match the existing decorator icon.

Depends on: https://github.com/ManageIQ/manageiq/pull/21701