### PR TITLE
Fix verify_credentials for an existing EMS

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -106,7 +106,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
     authentication = args.dig("authentications", "default")
     userid, password = authentication&.values_at("userid", "password")
     password = ManageIQ::Password.try_decrypt(password)
-    password ||= find(args["id"]).authentication_password(authtype) if args['id']
+    password ||= find(args["id"]).authentication_password("default") if args['id']
 
     !!raw_connect(hostname, port, userid, password, validate_ssl, true)
   end


### PR DESCRIPTION
When an EMS is being edited the password is not sent back down unless it is changed so we have to look it up when verifying credentials.

This was failing because of an undefined variable `authtype`.
<img width="1774" alt="2696c280-995f-11ec-974d-0d9e8bf2dd19" src="https://user-images.githubusercontent.com/12851112/156368377-3bc05008-e1a8-4e29-943a-26942106b32b.png">

