### PR TITLE
Raise HttpError after logging error

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -20,6 +20,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
       $ibm_power_hmc_log.info("end collection")
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("managed systems query failed: #{e}")
+      raise
     end
   end
 


### PR DESCRIPTION
If an 'IbmPowerHmc::Connection::HttpError' exception is encountered
during inventory collection it shouldn't be ignored. When ignored
something like a timeout can cause the collector to "successfully"
collect nothing and give the user an empty inventory with no error
messages.