### PR TITLE
Remove misplaced 'ems_ref' from log message

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -89,7 +89,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
     manager.with_provider_connection do |connection|
       @ssps = connection.ssps # we gather every ssp.
     rescue IbmPowerHmc::Connection::HttpError => e
-      $ibm_power_hmc_log.error("error querying ssps  #{ems_ref}: #{e}") unless e.status == 404
+      $ibm_power_hmc_log.error("error querying ssps: #{e}") unless e.status == 404
       nil
     end
     @ssps || []


### PR DESCRIPTION
Other methdods in this module iterate over 'ems_ref' of resources, but
SSPS collect everything with a single call to 'connection.ssps'. The log
message was probably copied from the other block without removing the
'ems_ref'.