### PR TITLE
Set host 'vmm_vendor' to display HMC icon

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -19,7 +19,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
         :hypervisor_hostname => "#{sys.mtype}#{sys.model}_#{sys.serial}",
         :hostname            => sys.hostname,
         :ipaddress           => sys.ipaddr,
-        :power_state         => lookup_power_state(sys.state)
+        :power_state         => lookup_power_state(sys.state),
+        :vmm_vendor          => "ibm_power_hmc"
       )
 
       parse_host_operating_system(host, sys)


### PR DESCRIPTION
If 'vmm_vendor' is not set the UI displays a question mark icon and
"Unknown" in the VMM Information.

Depends on:
- https://github.com/ManageIQ/manageiq-decorators/pull/69
- https://github.com/ManageIQ/manageiq/pull/21776