### PR TITLE
Check if PCM is enabled on host

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -19,6 +19,8 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   supports :metrics
   supports :provisioning
 
+  has_many :hosts_advanced_settings, :through => :hosts, :source => :advanced_settings
+
   def self.params_for_create
     @params_for_create ||= {
       :fields => [

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -23,6 +23,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       :manager => ems_event.ext_management_system,
       :event   => ems_event
     )
+    new_targets = []
 
     raw_event = ems_event.full_data
 
@@ -32,34 +33,31 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       elems = elem(raw_event[:data])
       case elems[:type]
       when "ManagedSystem"
-        elems[:assoc] = :hosts
-        elems[:ems_ref] = elems[:uuid]
+        new_targets << {:assoc => :hosts, :ems_ref => elems[:uuid]}
       when "LogicalPartition", "VirtualIOServer"
         # raw_event[:detail] contains information about the properties that
         # have changed (e.g. RMCState, PartitionName, PartitionState etc...)
         # This may be used to perform quick property REST API calls to the HMC
         # instead of querying the full LPAR data.
-        elems[:assoc] = :vms
-        elems[:ems_ref] = elems[:uuid]
+        new_targets << {:assoc => :vms, :ems_ref => elems[:uuid]}
       when "VirtualSwitch", "VirtualNetwork"
         if elems.key?(:manager_uuid)
-          elems[:assoc] = :hosts
-          elems[:ems_ref] = elems[:manager_uuid]
+          new_targets << {:assoc => :hosts, :ems_ref => elems[:manager_uuid]}
         end
       when "UserTask"
-        elems.merge!(handle_usertask(raw_event[:usertask]))
+        new_targets.concat(handle_usertask(raw_event[:usertask]))
       when "Cluster"
-        elems[:assoc] = :storages
-        elems[:ems_ref] = elems[:uuid]
+        new_targets << {:assoc => :storages, :ems_ref => elems[:uuid]}
       end
 
-      if elems.key?(:assoc)
-        $ibm_power_hmc_log.info("#{self.class}##{__method__} #{elems[:type]} uuid #{elems[:uuid]}")
+      new_targets.each do |t|
+        $ibm_power_hmc_log.info("#{self.class}##{__method__} #{elems[:type]} uuid #{t[:ems_ref]}")
         target_collection.add_target(
-          :association => elems[:assoc],
-          :manager_ref => {:ems_ref => elems[:ems_ref]}
+          :association => t[:assoc],
+          :manager_ref => {:ems_ref => t[:ems_ref]}
         )
       end
+      target_collection
     end
 
     # Return the set of targets from this event
@@ -67,17 +65,25 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
   end
 
   def handle_usertask(usertask)
+    r = []
     if usertask["status"].eql?("Completed")
       case usertask["key"]
       when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_PARTITION_SAVE_AS", "TEMPLATE_PARTITION_CAPTURE"
-        r = {:assoc => :miq_templates, :ems_ref => usertask['template_uuid']}
+        r << {:assoc => :miq_templates, :ems_ref => usertask['template_uuid']}
       when "TEMPLATE_DELETE"
         template = ManageIQ::Providers::InfraManager::Template.find_by(:ems_id => ems_event.ext_management_system.id, :name => usertask['labelParams'])
         unless template.nil?
-          r = {:assoc => :miq_templates, :ems_ref => template.uid_ems}
+          r << {:assoc => :miq_templates, :ems_ref => template.uid_ems}
+        end
+      when "PCM_PREFERENCE_UPDATE"
+        usertask['labelParams'].first.tr("[] ", "").split(",").each do |hostname|
+          host = ManageIQ::Providers::IbmPowerHmc::InfraManager::Host.find_by(:ems_id => ems_event.ext_management_system.id, :name => hostname)
+          unless host.nil?
+            r << {:assoc => :hosts, :ems_ref => host.ems_ref}
+          end
         end
       end
     end
-    r || {}
+    r
   end
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -84,7 +84,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
   end
 
   def handle_usertask_template_delete(usertask)
-    template = ManageIQ::Providers::InfraManager::Template.find_by(:ems_id => ems_event.ext_management_system.id, :name => usertask['labelParams'])
+    template = ManageIQ::Providers::InfraManager::Template.find_by(:ext_management_system => ems_event.ext_management_system, :name => usertask['labelParams'])
     if template.nil?
       []
     else
@@ -93,11 +93,8 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
   end
 
   def handle_usertask_pcm_preference(usertask)
-    usertask['labelParams'].first.tr("[] ", "").split(",").each_with_object([]) do |hostname, array|
-      host = ManageIQ::Providers::IbmPowerHmc::InfraManager::Host.find_by(:ext_management_system => ems_event.ext_management_system, :name => hostname)
-      unless host.nil?
-        array << {:assoc => :hosts, :ems_ref => host.ems_ref}
-      end
-    end
+    hostnames     = usertask['labelParams'].first.tr("[] ", "").split(",")
+    host_ems_refs = ManageIQ::Providers::IbmPowerHmc::InfraManager::Host.where(:ext_management_system => ems_event.ext_management_system, :name => hostnames).pluck(:ems_ref)
+    host_ems_refs.map { |ems_ref| {:assoc => :hosts, :ems_ref => ems_ref} }
   end
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -94,7 +94,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
 
   def handle_usertask_pcm_preference(usertask)
     usertask['labelParams'].first.tr("[] ", "").split(",").each_with_object([]) do |hostname, array|
-      host = ManageIQ::Providers::IbmPowerHmc::InfraManager::Host.find_by(:ems_id => ems_event.ext_management_system.id, :name => hostname)
+      host = ManageIQ::Providers::IbmPowerHmc::InfraManager::Host.find_by(:ext_management_system => ems_event.ext_management_system, :name => hostname)
       unless host.nil?
         array << {:assoc => :hosts, :ems_ref => host.ems_ref}
       end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
@@ -1,6 +1,10 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Host < ::Host
   include ManageIQ::Providers::IbmPowerHmc::InfraManager::MetricsCaptureMixin
 
+  supports :capture do
+    unsupported_reason_add(:capture, _("PCM not enabled for this Host")) unless advanced_settings.find { |s| s.name.eql?("pcm_enabled") }&.value.eql?("true")
+  end
+
   def collect_samples(start_time, end_time)
     ext_management_system.with_provider_connection do |connection|
       connection.managed_system_metrics(

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Host < ::Host
   include ManageIQ::Providers::IbmPowerHmc::InfraManager::MetricsCaptureMixin
 
   supports :capture do
-    unsupported_reason_add(:capture, _("PCM not enabled for this Host")) unless advanced_settings.find { |s| s.name.eql?("pcm_enabled") }&.value.eql?("true")
+    unsupported_reason_add(:capture, _("PCM not enabled for this Host")) unless pcm_enabled
   end
 
   def collect_samples(start_time, end_time)
@@ -31,6 +31,17 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Host < ::Host
       end.compact.to_h
     end || {}
   end
+
+  def pcm_enabled
+    as = advanced_settings.detect { |s| s.name == "pcm_enabled" }
+    if as.nil?
+      false
+    else
+      ActiveRecord::Type::Boolean.new.cast(as.value)
+    end
+  end
+
+  virtual_column :pcm_enabled, :type => :boolean, :uses => :advanced_settings
 
   private
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -135,7 +135,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def do_pcm_preferences(connection)
-    @pcm_enabled = connection.pcm_preferences.first.managed_system_preferences.each_with_object({}) { |v, h| h[v.id] = v }
+    @pcm_enabled = connection.pcm_preferences.first.managed_system_preferences.index_by(&:id)
   rescue IbmPowerHmc::Connection::HttpError => e
     $ibm_power_hmc_log.error("pcm preferences query failed: #{e}")
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -20,15 +20,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
           nil
         end.compact
 
-      @vswitches ||= {}
-      @vlans ||= {}
-      @cecs.each do |cec|
-        @vswitches[cec.uuid] = connection.virtual_switches(cec.uuid)
-        @vlans[cec.uuid] = connection.virtual_networks(cec.uuid)
-      rescue IbmPowerHmc::Connection::HttpError => e
-        $ibm_power_hmc_log.error("error querying virtual_switches or virtual_networks for managed system  #{cec.uuid}: #{e}") unless e.status == 404
-      end
-
+      do_vswitches(connection)
+      do_vlans(connection)
       do_pcm_preferences(connection)
     end
     @cecs || []

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -28,7 +28,9 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
       rescue IbmPowerHmc::Connection::HttpError => e
         $ibm_power_hmc_log.error("error querying virtual_switches or virtual_networks for managed system  #{cec.uuid}: #{e}") unless e.status == 404
       end
+      do_pcm_preferences(connection)
     end
+    @cecs || []
   end
 
   def lpars

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -28,6 +28,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
       rescue IbmPowerHmc::Connection::HttpError => e
         $ibm_power_hmc_log.error("error querying virtual_switches or virtual_networks for managed system  #{cec.uuid}: #{e}") unless e.status == 404
       end
+
       do_pcm_preferences(connection)
     end
     @cecs || []

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -25,6 +25,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
 
       parse_host_operating_system(host, sys)
       parse_host_hardware(host, sys)
+      parse_host_advanced_settings(host, sys)
       parse_vswitches(host, sys)
       parse_vlans(sys)
     end
@@ -87,6 +88,17 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     #   :device_name => sys.xxx,
     #   :device_type => sys.xxx
     # )
+  end
+
+  def parse_host_advanced_settings(host, sys)
+    persister.hosts_advanced_settings.build(
+      :resource     => host,
+      :name         => "pcm_enabled",
+      :display_name => _("PCM-enabled"),
+      :description  => _("Performance and Capacity Monitoring data collection enabled"),
+      :value        => collector.pcm_enabled[sys.uuid].aggregation,
+      :read_only    => true
+    )
   end
 
   def parse_lpars

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -21,5 +21,12 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
         :parent_inventory_collections => %i[vms]
       )
     end
+    add_collection(infra, :hosts_advanced_settings) do |builder|
+      builder.add_properties(
+        :manager_ref                  => %i[resource name],
+        :model_class                  => ::AdvancedSetting,
+        :parent_inventory_collections => %i[hosts]
+      )
+    end
   end
 end

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.9.0"
+  spec.add_dependency "ibm_power_hmc", "~> 0.10.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/factories/advanced_setting.rb
+++ b/spec/factories/advanced_setting.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+    factory :ibm_power_hmc_advanced_setting,
+            :class   => "AdvancedSetting"
+  end

--- a/spec/factories/advanced_setting.rb
+++ b/spec/factories/advanced_setting.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  factory :ibm_power_hmc_advanced_setting,
-          :class => "AdvancedSetting"
-end

--- a/spec/factories/advanced_setting.rb
+++ b/spec/factories/advanced_setting.rb
@@ -1,4 +1,4 @@
 FactoryBot.define do
-    factory :ibm_power_hmc_advanced_setting,
-            :class   => "AdvancedSetting"
-  end
+  factory :ibm_power_hmc_advanced_setting,
+          :class => "AdvancedSetting"
+end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -2,6 +2,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
   before :each do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems                 = FactoryBot.create(:ems_ibm_power_hmc_infra, :zone => zone)
+    User.seed
   end
 
   context "ADD_URI event" do

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -111,7 +111,6 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
     end
   end
 
-
   def assert_event_triggers_target(filename, expected_targets, usertask = nil)
     ems_event      = create_ems_event(filename, usertask)
     parsed_targets = described_class.new(ems_event).parse

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -87,7 +87,30 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
         [[:storages, {:ems_ref => 'c1e50c27-888c-3c4d-8d4a-53a3768ea250'}]]
       )
     end
+    it "PcmPreferences" do
+      aramis = FactoryBot.create(:ibm_power_hmc_host, :ext_management_system => @ems, :ems_ref => "aaaaaaaa-eaa8-3a54-b4dc-93346276ea37", :name => "aramis")
+      porthos = FactoryBot.create(:ibm_power_hmc_host, :ext_management_system => @ems, :ems_ref => "bbbbbbbb-eaa8-3a54-b4dc-93346276ea37", :name => "porthos")
+      assert_event_triggers_target(
+        "test_data/pcm_preferences.xml",
+        [
+          [:hosts, {:ems_ref => aramis.ems_ref}],
+          [:hosts, {:ems_ref => porthos.ems_ref}]
+        ],
+        {
+          "uuid"           => "99630d72-36b7-4fa6-8307-b70aef13b0b0",
+          "key"            => "PCM_PREFERENCE_UPDATE",
+          "localizedLabel" => "Update performance monitoring settings",
+          "labelParams"    => ["[aramis, porthos]"],
+          "initiator"      => "hscroot",
+          "timeStarted"    => 1_652_866_657_499,
+          "timeCompleted"  => 1_652_866_657_594,
+          "status"         => "Completed",
+          "visible"        => true
+        }
+      )
+    end
   end
+
 
   def assert_event_triggers_target(filename, expected_targets, usertask = nil)
     ems_event      = create_ems_event(filename, usertask)

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/host_spec.rb
@@ -40,5 +40,19 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Host do
         }
       )
     end
+
+    it "supports metrics capture (no setting)" do
+      expect(host.supports?(:capture)).to be false
+    end
+
+    it "supports metrics capture (false)" do
+      FactoryBot.create(:ibm_power_hmc_advanced_setting, :name => "pcm_enabled", :resource => host, :value => "false")
+      expect(host.supports?(:capture)).to be false
+    end
+
+    it "supports metrics capture (true)" do
+      FactoryBot.create(:ibm_power_hmc_advanced_setting, :name => "pcm_enabled", :resource => host, :value => "true")
+      expect(host.supports?(:capture)).to be true
+    end
   end
 end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/host_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/host_spec.rb
@@ -46,12 +46,12 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Host do
     end
 
     it "supports metrics capture (false)" do
-      FactoryBot.create(:ibm_power_hmc_advanced_setting, :name => "pcm_enabled", :resource => host, :value => "false")
+      FactoryBot.create(:advanced_settings, :name => "pcm_enabled", :resource => host, :value => "false")
       expect(host.supports?(:capture)).to be false
     end
 
     it "supports metrics capture (true)" do
-      FactoryBot.create(:ibm_power_hmc_advanced_setting, :name => "pcm_enabled", :resource => host, :value => "true")
+      FactoryBot.create(:advanced_settings, :name => "pcm_enabled", :resource => host, :value => "true")
       expect(host.supports?(:capture)).to be true
     end
   end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/pcm_preferences.xml
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/pcm_preferences.xml
@@ -1,0 +1,31 @@
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+    <id>064240ce-c295-34cb-a0b5-8e6ee0e7a615</id>
+    <updated>2022-05-18T10:37:30.571+01:00</updated>
+    <link rel="SELF" href="https://te.st:12443/rest/api/uom/Event"/>
+    <link rel="MANAGEMENT_CONSOLE" href="https://te.st:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+    <generator>IBM Power Systems Management Console</generator>
+    <entry>
+        <id>443b9747-0263-3ca3-b5b4-6de57d4e04f0</id>
+        <title>Event</title>
+        <published>2022-05-18T10:37:37.516+01:00</published>
+        <link rel="SELF" href="https://te.st:12443/rest/api/uom/Event/443b9747-0263-3ca3-b5b4-6de57d4e04f0"/>
+        <author>
+            <name>IBM Power Systems Management Console</name>
+        </author>
+        <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1820497910</etag:etag>
+        <content type="application/vnd.ibm.powervm.uom+xml; type=Event">
+            <Event:Event xmlns:Event="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+    <Metadata>
+        <Atom>
+            <AtomID>443b9747-0263-3ca3-b5b4-6de57d4e04f0</AtomID>
+            <AtomCreated>1652866657515</AtomCreated>
+        </Atom>
+    </Metadata>
+    <EventType kxe="false" kb="ROR">ADD_URI</EventType>
+    <EventID kxe="false" kb="ROR">1652685719619</EventID>
+    <EventData kb="ROR" kxe="false">https://te.st:12443/rest/api/uom/UserTask/99630d72-36b7-4fa6-8307-b70aef13b0b0</EventData>
+    <EventDetail kxe="false" kb="ROR">Other</EventDetail>
+</Event:Event>
+        </content>
+    </entry>
+</feed>


### PR DESCRIPTION
Retrieve Performance and Capacity Monitor preferences for each Host and store it so ManageIQ does not try to collect metrics for a host and its VMs if there is nothing to collect.