### PR TITLE
[WIP] Display only CPU usage charts for Hosts

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
@@ -84,6 +84,19 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Host < ::Host
 
   virtual_column :pcm_enabled, :type => :boolean, :uses => :advanced_settings
 
+  # Display or hide certain performance charts
+  def cpu_mhz_available?
+    false
+  end
+
+  def cpu_ready_available?
+    false
+  end
+
+  def cpu_percent_available?
+    true
+  end
+
   private
 
   def get_sample_value(sample, key)


### PR DESCRIPTION
Override new methods added in https://github.com/ManageIQ/manageiq/pull/21909 to display Host CPU usage charts only.