### PR TITLE
Handle case where VM or Template does not have any OS info

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -175,13 +175,15 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   end
 
   def parse_vm_operating_system(vm, lpar)
-    os_info = lpar.os.split
-    persister.operating_systems.build(
-      :vm_or_template => vm,
-      :product_name   => os_info[0],
-      :version        => os_info[1],
-      :build_number   => os_info[2]
-    )
+    os_info = lpar.os&.split
+    if os_info
+      persister.operating_systems.build(
+        :vm_or_template => vm,
+        :product_name   => os_info[0],
+        :version        => os_info[1],
+        :build_number   => os_info[2]
+      )
+    end
   end
 
   def parse_vm_guest_devices(lpar, hardware)


### PR DESCRIPTION
This can happen for Templates, where OS information can be left out. This generates a nil dereferencing.