### PR TITLE
[Najdorf] Explicitly declare Template cloning as not supported

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
+  supports_not :clone
 end


### PR DESCRIPTION
The Template view is leaving Template cloning enabled even though this is not supported in this version. Clicking on this menu item leaves the user with a blank form.

![image](https://user-images.githubusercontent.com/82665100/182798214-66399775-aa33-4810-9a5c-0971501e1853.png)


The menu item is checking the list of supported features of the record

https://github.com/ManageIQ/manageiq-ui-classic/blob/najdorf/app/helpers/application_helper/button/generic_feature_button.rb
https://github.com/ManageIQ/manageiq-ui-classic/blob/c98fb3d7091db45a707b332ab7b7949119c2e38a/app/helpers/application_helper/toolbar/x_miq_template_center.rb#L98
https://github.com/ManageIQ/manageiq-ui-classic/blob/c98fb3d7091db45a707b332ab7b7949119c2e38a/app/helpers/application_helper.rb#L203

![image](https://user-images.githubusercontent.com/82665100/182798632-75487b5e-7512-4b8f-9c58-f879cc31d2e7.png)

By explicitly declaring Template cloning as not supported, the menu item is disabled.