### PR TITLE
Fix Psych warning regarding '-'

### DIFF
--- a/content/miq_dialogs/miq_provision_ibm_power_hmc_dialogs_clone_to_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_power_hmc_dialogs_clone_to_template.yaml
@@ -34,9 +34,9 @@
           :required_method:
           - :validate_vm_name
           - :validate_regex
-          :required_regex: !ruby/regexp /\A(?:[A-Za-z0-9-_]+)\Z/
-          :required_regex_fail_details: "The name must be composed only of letters (A-Z or a-z), numbers (0-9) or
-            characters '-' and '_'."
+          :required_regex: !ruby/regexp /\A(?:[A-Za-z0-9_-]+)\Z/
+          :required_regex_fail_details: "The name must be composed only of letters (A-Z or a-z), numbers (0-9), or
+            characters '_' and '-'."
           :required: true
           :notes:
           :display: :edit

--- a/content/miq_dialogs/miq_provision_ibm_power_hmc_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_power_hmc_dialogs_template.yaml
@@ -34,9 +34,9 @@
           :required_method:
           - :validate_vm_name
           - :validate_regex
-          :required_regex: !ruby/regexp /\A(?:[A-Za-z0-9-_]+)\Z/
-          :required_regex_fail_details: "The name must be composed only of letters (A-Z or a-z), numbers (0-9) or
-            characters '-' and '_'."
+          :required_regex: !ruby/regexp /\A(?:[A-Za-z0-9_-]+)\Z/
+          :required_regex_fail_details: "The name must be composed only of letters (A-Z or a-z), numbers (0-9), or
+            characters '_' and '-'."
           :required: true
           :notes:
           :display: :edit


### PR DESCRIPTION
Psych warns:

    ~/.rubies/ruby-2.7.6/lib/ruby/2.7.0/psych/visitors/to_ruby.rb:106: warning: character class has '-' without escape: /\A(?:[A-Za-z0-9-_]+)\Z/
    ~/.gem/ruby/2.7.6/gems/activesupport-6.1.6.1/lib/active_support/core_ext/marshal.rb:8: warning: character class has '-' without escape: /\A(?:[A-Za-z0-9-_]+)\Z/

The fix here is to just put the '-' at the end of the character class.
Otherwise, the character class is unsure if the '-' is to be used as a
range indicator or not. At the end it is unambiguously not a range
indicator.