### PR TITLE
Fix/parent deprecated

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/runner.rb
@@ -23,7 +23,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Runner < Man
 
   def event_monitor_handle
     @event_monitor_handle ||= begin
-      self.class.parent::Stream.new(
+      self.class.module_parent::Stream.new(
         @ems,
         :poll_sleep => worker_settings[:poll]
       )


### PR DESCRIPTION
To avoid this (from evm.log) : 
```
MIQ(ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Runner#start_event_monitor) EMS [coophmc2.coopibm.frec.bull.fr] as [hscroot] Event Monitor Thread aborted because [undefined method `parent' for #<Class:0x0000010023b193c8>
```

We need to change `Foo.class.parent` for `Foo.class.module_parent` because `parent` method is deprecated in Rails `6.1.x`

See the warning here : https://apidock.com/rails/v6.0.0/Module/parent