### PR TITLE
Add setting to adjust HMC API request timeout

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -143,7 +143,14 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   def self.raw_connect(hostname, port, userid, password, validate_ssl, validate)
     require "ibm_power_hmc"
 
-    hc = IbmPowerHmc::Connection.new(:host => hostname, :port => port, :username => userid, :password => password, :validate_ssl => validate_ssl)
+    hc = IbmPowerHmc::Connection.new(
+      :host         => hostname,
+      :port         => port,
+      :username     => userid,
+      :password     => password,
+      :validate_ssl => validate_ssl,
+      :timeout      => Settings.ems.ems_ibm_power_hmc.api_request_timeout
+    )
     if validate
       # Do a logon/logoff to verify credentials
       hc.logon

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,6 @@
 :ems:
   :ems_ibm_power_hmc:
+    :api_request_timeout: 60
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.12.0"
+  spec.add_dependency "ibm_power_hmc", "~> 0.12.2"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
When hosts have lost their connection to an HMC, the Managed System(s) APIs will take 2+ minutes to respond. The default response timeout for the rest-client gem is 60 seconds. Adding a user configurable setting to override the API request timeout allows inventory refresh to succeed, even when the responses are slow due to disconnected systems (or possible other reasons).

~The default value of 180 seconds should be enough to allow inventory refresh to pass in most cases, but still fail in a timely manner in the event of a "real" timeout.~

After further discussion, I set the default timeout value to 60 seconds. The intention is to leave existing behavior unchanged _unless_ the user changes the setting introduced here.

Depends on:
- https://github.com/IBM/ibm_power_hmc_sdk_ruby/pull/82
- [ ] Release `ibm_power_hmc` v0.12.1 with ^