### PR TITLE
Insert IP address used by RMC as a VM IP address

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -138,6 +138,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     end
 
     parse_vm_operating_system(vm, lpar)
+    parse_vm_ip_address(lpar, hardware)
     parse_vm_guest_devices(lpar, hardware)
     parse_vm_advanced_settings(vm, lpar)
     vm
@@ -149,6 +150,16 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :memory_mb       => lpar.memory,
       :cpu_total_cores => lpar.dedicated.eql?("true") ? lpar.procs.to_i : lpar.vprocs.to_i
     )
+  end
+
+  def parse_vm_ip_address(lpar, hardware)
+    if lpar.rmc_ipaddr
+      persister.networks.build(
+        :ipaddress   => lpar.rmc_ipaddr,
+        :ipv6address => nil,
+        :hardware    => hardware
+      )
+    end
   end
 
   def parse_vswitches(host, sys)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -138,7 +138,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     end
 
     parse_vm_operating_system(vm, lpar)
-    parse_vm_ip_address(lpar, hardware)
+    parse_vm_networks(lpar, hardware)
     parse_vm_guest_devices(lpar, hardware)
     parse_vm_advanced_settings(vm, lpar)
     vm
@@ -152,7 +152,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     )
   end
 
-  def parse_vm_ip_address(lpar, hardware)
+  def parse_vm_networks(lpar, hardware)
     if lpar.rmc_ipaddr
       persister.networks.build(
         :ipaddress   => lpar.rmc_ipaddr,

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :host_virtual_lans)
     add_collection(infra, :storages)
     add_collection(infra, :disks)
+    add_collection(infra, :networks)
     add_collection(infra, :vms_and_templates_advanced_settings) do |builder|
       builder.add_properties(
         :manager_ref                  => %i[resource name],


### PR DESCRIPTION
The HMC does not give us visibility above the networking data link layer, so we are only able to display MAC address for each network interface. 

However, the HMC knows one of the IP address of the VM in order to communicate with it through Resource Monitoring Control. In many cases, this would be the IP address the VM is known by, so it has been suggested the provider should display this address in ManageIQ. Subnet mask is not available.

Screen captures after modification:
![image](https://user-images.githubusercontent.com/82665100/191257068-67e4589b-3921-42cf-b3cf-fdce9600abac.png)
![image](https://user-images.githubusercontent.com/82665100/191257289-0e75a7a5-cd7b-4062-8d58-a317928bfd0d.png)
![image](https://user-images.githubusercontent.com/82665100/191257407-81a0c335-66b3-4980-be63-10117828fbb5.png)
