### PR TITLE
Handle case where PCM enabled setting is not available

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -92,14 +92,16 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   end
 
   def parse_host_advanced_settings(host, sys)
-    persister.hosts_advanced_settings.build(
-      :resource     => host,
-      :name         => "pcm_enabled",
-      :display_name => _("PCM-enabled"),
-      :description  => _("Performance and Capacity Monitoring data collection enabled"),
-      :value        => collector.pcm_enabled[sys.uuid].aggregation,
-      :read_only    => true
-    )
+    if collector.pcm_enabled[sys.uuid]
+      persister.hosts_advanced_settings.build(
+        :resource     => host,
+        :name         => "pcm_enabled",
+        :display_name => _("PCM-enabled"),
+        :description  => _("Performance and Capacity Monitoring data collection enabled"),
+        :value        => collector.pcm_enabled[sys.uuid].aggregation,
+        :read_only    => true
+      )
+    end
   end
 
   def parse_lpars


### PR DESCRIPTION
When we increase the timeout in order to receive all CECs, we gather hosts with `no connection` state.
This creates a bug because in that case we don't have PCM informations

This patchs is supposed to resolve it

Signed-off-by: HANRIAT Calliste <hanriat.calliste@ibm.com>