### PR TITLE
[WIP] implement console_url to redirect to the HMC console

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -17,6 +17,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
 
   supports :create
   supports :metrics
+  supports :native_console
   supports :provisioning
 
   has_many :hosts_advanced_settings, :through => :hosts, :source => :advanced_settings
@@ -158,6 +159,10 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
     end
 
     hc
+  end
+
+  def console_url
+    "https://#{hostname}/dashboard/"
   end
 
   def self.ems_type


### PR DESCRIPTION
This allows to access the native HMC console from the MiQ UI:

![image](https://user-images.githubusercontent.com/48122102/192524183-bf6e8837-6578-429f-9901-3f32751d8f00.png)
