### PR TITLE
Collect LPAR disks using VSCSI mappings

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -150,15 +150,15 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   def lpar_disks_from_api
     @lpar_disks_from_api ||= vscsi_mappings.map do |m|
       {
-        :lpar_uuid   => m.lpar_uuid,
-        :client_drc  => m.client.location,
-        :udid        => m.storage.udid,
-        :thin        => m.storage.respond_to?(:thin) ? m.storage.thin == "true" : nil,
-        :cluster_id  => m.device.try(:cluster_id),
-        :storage     => m.storage,
-        :type        => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? "cdrom" : "disk",
-        :mode        => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? m.storage.mount_opts : "rw",
-        :path        => m.device.kind_of?(IbmPowerHmc::SharedFileSystemFileVirtualTargetDevice) ? m.device.path : nil
+        :lpar_uuid  => m.lpar_uuid,
+        :client_drc => m.client.location,
+        :udid       => m.storage.udid,
+        :thin       => m.storage.respond_to?(:thin) ? m.storage.thin == "true" : nil,
+        :cluster_id => m.device.try(:cluster_id),
+        :storage    => m.storage,
+        :type       => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? "cdrom" : "disk",
+        :mode       => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? m.storage.mount_opts : "rw",
+        :path       => m.device.kind_of?(IbmPowerHmc::SharedFileSystemFileVirtualTargetDevice) ? m.device.path : nil
       }
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -157,7 +157,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
         :cluster_id => m.device.try(:cluster_id),
         :storage    => m.storage,
         :type       => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? "cdrom" : "disk",
-        :path       => m.device.kind_of?(IbmPowerHmc::SharedFileSystemFile) ? m.device.path : nil
+        :path       => m.device.kind_of?(IbmPowerHmc::SharedFileSystemFileVirtualTargetDevice) ? m.device.path : nil
       }
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -150,14 +150,15 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   def lpar_disks_from_api
     @lpar_disks_from_api ||= vscsi_mappings.map do |m|
       {
-        :lpar_uuid  => m.lpar_uuid,
-        :client_drc => m.client.location,
-        :udid       => m.storage.udid,
-        :thin       => m.storage.respond_to?(:thin) ? m.storage.thin == "true" : nil,
-        :cluster_id => m.device.try(:cluster_id),
-        :storage    => m.storage,
-        :type       => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? "cdrom" : "disk",
-        :path       => m.device.kind_of?(IbmPowerHmc::SharedFileSystemFileVirtualTargetDevice) ? m.device.path : nil
+        :lpar_uuid   => m.lpar_uuid,
+        :client_drc  => m.client.location,
+        :udid        => m.storage.udid,
+        :thin        => m.storage.respond_to?(:thin) ? m.storage.thin == "true" : nil,
+        :cluster_id  => m.device.try(:cluster_id),
+        :storage     => m.storage,
+        :type        => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? "cdrom" : "disk",
+        :mode        => m.storage.kind_of?(IbmPowerHmc::VirtualOpticalMedia) ? m.storage.mount_opts : "rw",
+        :path        => m.device.kind_of?(IbmPowerHmc::SharedFileSystemFileVirtualTargetDevice) ? m.device.path : nil
       }
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -151,7 +151,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     @lpar_disks_from_api ||= vscsi_mappings.map do |m|
       {
         :lpar_uuid  => m.lpar_uuid,
-        :client_dr  => m.client.location,
+        :client_drc => m.client.location,
         :udid       => m.storage.udid,
         :thin       => m.storage.respond_to?(:thin) ? m.storage.thin == "true" : nil,
         :cluster_id => m.device.try(:cluster_id),

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
 
     manager.with_provider_connection do |connection|
       @connection = connection
-      infer_ems_refs_from_api
+      infer_related_ems_refs_api!
     end
 
     target.manager_refs_by_association_reset
@@ -67,7 +67,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
     end.compact
   end
 
-  def infer_ems_refs_from_api
+  def infer_related_ems_refs_api!
     # Refresh LPARs that have disk paths going through any of the updated VIOSes.
     vscsi_mappings.each do |m|
       $ibm_power_hmc_log.debug("#{self.class}##{__method__} add LPAR target #{m.lpar_uuid}")

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -87,6 +87,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
           :client_drc => path,
           :udid       => disk.device_name,
           :size       => disk.size,
+          :mode       => disk.mode,
+          :disk_type  => disk.disk_type,
           :thin       => disk.thin,
           :type       => disk.device_type,
           :path       => disk.filename

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -76,10 +76,8 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
   end
 
   def lpar_disks_from_db
-    # Limit DB query to LPARs only (not VIOSes) and only for the ones that still exist.
-    @lpar_disks_from_db ||= manager.vms.where(:ems_ref => lpars.collect(&:uuid)).joins(:disks).select("vms.ems_ref as lpar_uuid", "disks.*").flat_map do |disk|
-      next unless vscsi_client_adapters.key?(disk.lpar_uuid)
-
+    # Limit DB query to LPARs only (not VIOSes) and only for the ones that still have VSCSI client adapters.
+    @lpar_disks_from_db ||= manager.vms.where(:ems_ref => vscsi_client_adapters.keys).joins(:disks).select("vms.ems_ref as lpar_uuid", "disks.*").flat_map do |disk|
       disk.location.split(",").map do |path|
         # Preserve only paths to VIOSes that are not part of the target refresh.
         next if vscsi_client_adapters[disk.lpar_uuid].any? { |c| c.location == path && references(:vms).include?(c.vios_uuid) }

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -63,7 +63,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
 
       persister.disks.build(
         :hardware        => hardware,
-        :location        => paths.collect { |d| d[:client_drc] }.sort.uniq.join(","),
+        :location        => paths.pluck(:client_drc).sort.uniq.join(","),
         :device_name     => udid,
         :device_type     => disk[:type],
         :storage         => disk[:cluster_id] ? persister.storages.lazy_find(disk[:cluster_id]) : nil,

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -94,12 +94,17 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
 
   def parse_vios_disks(vios, hardware)
     vios.pvs.each do |pv|
+      size = self.class.storage_capacity(pv)
+
       persister.disks.build(
         :hardware        => hardware,
-        :device_type     => "disk",
-        :device_name     => pv.name,
-        :size            => self.class.storage_capacity(pv),
         :location        => pv.location,
+        :device_name     => pv.name,
+        :device_type     => "disk",
+        :size            => size,
+        :size_on_disk    => size,
+        :mode            => "rw",
+        :disk_type       => self.class.storage_type(pv),
         :controller_type => pv.is_fc == "true" ? "FC" : "SCSI"
       )
     end


### PR DESCRIPTION
The idea here is to refresh LPARs that have disks attached to the VIOS when the VIOS is updated.
Disks coming from other VIOSes are queried from DB.
We manage multi-pathing using the location code of the disk as a list of client adapter names.