### PR TITLE
Fix poll sleep interval in event catcher and make sure we can exit the poll loop

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Stream
-  def initialize(ems, options = {})
+  def initialize(ems, _options = {})
     @ems = ems
     @last_activity = nil
     @stop_polling = false

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
@@ -1,12 +1,8 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Stream
-  class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
-  end
-
   def initialize(ems, options = {})
     @ems = ems
     @last_activity = nil
     @stop_polling = false
-    @poll_sleep = options[:poll_sleep] || 20.seconds
   end
 
   def start
@@ -17,19 +13,13 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Stream
     @stop_polling = true
   end
 
-  def poll
+  def poll(&block)
     @ems.with_provider_connection do |connection|
-      catch(:stop_polling) do
-        loop do
-          connection.next_events(false).each do |event|
-            throw :stop_polling if @stop_polling
-            yield event
-          end
-          sleep @poll_sleep
-        end
-      rescue => exception
-        raise ProviderUnreachable, exception.message
-      end
+      # The HMC waits 10 seconds by default before returning if there is no event.
+      connection.next_events(false).each(&block) until @stop_polling
+    rescue IbmPowerHmc::Connection::HttpError => e
+      $ibm_power_hmc_log.error("querying hmc events failed: #{e}")
+      raise
     end
   end
 end


### PR DESCRIPTION
There is a possibility that we never exit the poll loop if no events are ever read from the HMC:

https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/blob/9470024cba887d6e31b11abe56ec632f2dabcb55/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb#L23-L29

This needs to be fixed by checking `@stop_polling` outside of the `next_events` loop.

Also, the HMC already waits about 10 seconds before returning if there is no event, so take that into account in the poll interval, otherwise we may end up waiting more than `10+@poll_sleep` seconds.