### PR TITLE
Fix bug in targeted collection

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
 
   def clusters
     @clusters ||= references(:storages).map do |ems_ref|
-      connection.clusters(ems_ref)
+      connection.cluster(ems_ref)
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("error querying cluster #{ems_ref}: #{e}") unless e.status == 404
       nil


### PR DESCRIPTION
Introduced by #89

This results in a "wrong number of parameters" error and causes targeted collection for storages to fail.