### PR TITLE
Collect host hardware devices

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -134,7 +134,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
 
   def parse_host_guest_devices(hardware, sys)
     sys.io_adapters.each do |io|
-      next if io.udid.to_i == 65535 # Skip empty slots
+      next if io.udid.to_i == 65_535 # Skip empty slots
 
       persister.host_guest_devices.build(
         :hardware        => hardware,

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :vms)
     add_collection(infra, :host_operating_systems)
     add_collection(infra, :host_hardwares)
+    add_collection(infra, :host_guest_devices)
     add_collection(infra, :hardwares)
     add_collection(infra, :miq_templates) # required by hardwares.vm_or_template
     add_collection(infra, :host_virtual_switches)


### PR DESCRIPTION
The HMC displays physical adapters of the managed systems:

![image](https://user-images.githubusercontent.com/48122102/194267065-cba9a8f0-9583-47ed-b1dc-4f885ce59f34.png)

With this change, the physical adapters show up like this in MIQ UI:

![image](https://user-images.githubusercontent.com/48122102/194267441-050cb1e8-f7b6-4861-90bc-7a2077067806.png)
