### PR TITLE
Add physical I/O adapters to VMs

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -243,6 +243,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     persister.hardwares.build(
       :vm_or_template  => vm,
       :memory_mb       => lpar.memory,
+      :cpu_type        => "ppc64",
       :cpu_total_cores => lpar.dedicated.eql?("true") ? lpar.procs.to_i : lpar.vprocs.to_i
     )
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -336,6 +336,20 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     lpar.lhea_ports.each do |ent|
       build_ethernet_dev(ent, hardware, "host ethernet adapter")
     end
+
+    # Physical adapters can be assigned to VIOSes and LPARs using IOMMU.
+    lpar.io_adapters.each do |io|
+      persister.guest_devices.build(
+        :hardware        => hardware,
+        :uid_ems         => io.dr_name,
+        :device_type     => "physical_port",
+        :controller_type => "IO",
+        :device_name     => "Adapter",
+        :location        => io.dr_name,
+        :model           => io.description,
+        :auto_detect     => true
+      )
+    end
   end
 
   def parse_lpar_guest_devices(lpar, hardware)

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.15.0"
+  spec.add_dependency "ibm_power_hmc", "~> 0.16.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
In PowerVM, it is possible to assign physical I/O adapters to a partition (VIOS or LPAR) using the IOMMU.
The HMC shows the physical I/O adapters attached to a partition like this:
![image](https://user-images.githubusercontent.com/48122102/194898918-af22823d-3293-4e42-8173-196a393faf1b.png)

With this change, we see them from MIQ like so:
![image](https://user-images.githubusercontent.com/48122102/194899992-d8c4cf77-9e57-4856-8374-c93cf44577e6.png)
