### PR TITLE
use new modify_object api to rename LPARs and VIOSes

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm
-  supports :rename do
-    unsupported_reason_add(:rename, _("Host is not HMC-managed")) unless host.hmc_managed
-  end
-
   supports :publish
 
   def provider_object(connection = nil)
@@ -28,15 +24,6 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers
       connection.poweroff_lpar(ems_ref, params)
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("error powering off LPAR #{ems_ref} with params=#{params}: #{e}")
-      raise
-    end
-  end
-
-  def raw_rename(new_name)
-    ext_management_system.with_provider_connection do |connection|
-      connection.rename_lpar(ems_ref, new_name)
-    rescue IbmPowerHmc::Connection::HttpError => e
-      $ibm_power_hmc_log.error("error renaming LPAR #{ems_ref} to #{new_name}: #{e}")
       raise
     end
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
   end
 
   supports :rename do
-    unsupported_reason_add(:rename, _("Host is not HMC-managed")) unless host.hmc_managed
+    unsupported_reason_add(:rename, _("Host is not HMC-managed")) unless host_hmc_managed
   end
 
   supports :native_console do


### PR DESCRIPTION
Renaming was only supported for LPARs (because the HMC SDK does not have a `rename_vios` method).
The HMC SDK now exports a generic `modify_object` method that allows to modify any attribute of any supported object types.