### PR TITLE
Filter out irrelevant HMC events

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher/stream.rb
@@ -16,7 +16,9 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher::Stream
   def poll(&block)
     @ems.with_provider_connection do |connection|
       # The HMC waits 10 seconds by default before returning if there is no event.
-      connection.next_events(false).each(&block) until @stop_polling
+      connection.next_events(false).select do |event|
+        event.type.in?(["ADD_URI", "MODIFY_URI", "DELETE_URI"])
+      end.each(&block) until @stop_polling
     rescue IbmPowerHmc::Connection::HttpError => e
       $ibm_power_hmc_log.error("querying hmc events failed: #{e}")
       raise

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
@@ -25,19 +25,15 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser
           event_hash[:host_ems_ref] = elems[-3]
         end
       when "VirtualSwitch"
-        event_hash[:vswitch_ems_ref] = uuid
         # Check if the URI also contains /ManagedSystem/{uuid}/
         if elems.length >= 4 && elems[-4] == "ManagedSystem"
           event_hash[:host_ems_ref] = elems[-3]
         end
       when "VirtualNetwork"
-        event_hash[:vlan_ems_ref] = uuid
         # Check if the URI also contains /ManagedSystem/{uuid}/
         if elems.length >= 4 && elems[-4] == "ManagedSystem"
           event_hash[:host_ems_ref] = elems[-3]
         end
-      when "Cluster"
-        event_hash[:storage_ems_ref] = uuid
       when "SharedProcessorPool"
         if elems.length >= 4 && elems[-4] == "ManagedSystem"
           event_hash[:host_ems_ref] = elems[-3]

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser.rb
@@ -5,40 +5,30 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser
       :source     => 'IBM_POWER_HMC',
       :ems_ref    => event.id,
       :timestamp  => event.published,
+      :message    => event.detail,
       # Serialize IbmPowerHmc::Event
       :full_data  => {:data => event.data, :detail => event.detail, :usertask => event.usertask},
       :ems_id     => ems_id
     }
 
-    case event.type
-    when /.*_URI/
-      uri = URI(event.data)
-      elems = uri.path.split('/')
-      type, uuid = elems[-2], elems[-1]
-      case type
-      when "ManagedSystem"
-        event_hash[:host_ems_ref] = uuid
-      when "LogicalPartition", "VirtualIOServer"
-        event_hash[:vm_ems_ref] = uuid
-        # Check if the URI also contains /ManagedSystem/{uuid}/
-        if elems.length >= 4 && elems[-4] == "ManagedSystem"
-          event_hash[:host_ems_ref] = elems[-3]
-        end
-      when "VirtualSwitch"
-        # Check if the URI also contains /ManagedSystem/{uuid}/
-        if elems.length >= 4 && elems[-4] == "ManagedSystem"
-          event_hash[:host_ems_ref] = elems[-3]
-        end
-      when "VirtualNetwork"
-        # Check if the URI also contains /ManagedSystem/{uuid}/
-        if elems.length >= 4 && elems[-4] == "ManagedSystem"
-          event_hash[:host_ems_ref] = elems[-3]
-        end
-      when "SharedProcessorPool"
-        if elems.length >= 4 && elems[-4] == "ManagedSystem"
-          event_hash[:host_ems_ref] = elems[-3]
-        end
-      end
+    elems = URI(event.data).path.split('/')
+    type, uuid = elems[-2], elems[-1]
+
+    # Check if the URI also contains /ManagedSystem/{uuid}/
+    if elems.length >= 4 && elems[-4] == "ManagedSystem"
+      host_uuid = elems[-3]
+    end
+
+    case type
+    when "ManagedSystem"
+      event_hash[:host_ems_ref] = uuid
+    when "LogicalPartition", "VirtualIOServer"
+      event_hash[:vm_ems_ref]   = uuid
+      event_hash[:host_ems_ref] = host_uuid unless host_uuid.nil?
+    when "VirtualSwitch", "VirtualNetwork", "SharedProcessorPool"
+      event_hash[:host_ems_ref] = host_uuid unless host_uuid.nil?
+    when "UserTask"
+      event_hash[:message] = event.usertask["key"]
     end
 
     event_hash

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,13 +5,13 @@
     :event_handling:
       :event_groups:
         :addition:
-          :critical:
+          :detail:
           - ADD_URI
         :configuration:
-          :critical:
+          :detail:
           - MODIFY_URI
         :deletion:
-          :critical:
+          :detail:
           - DELETE_URI
 :ems_refresh:
   :ibm_power_hmc:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,7 +9,6 @@
           - ADD_URI
         :configuration:
           :critical:
-          - INVALID_URI
           - MODIFY_URI
         :deletion:
           :critical:

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser_spec.rb
@@ -77,8 +77,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :vswitch_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
-          :host_ems_ref    => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
+          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
         )
       )
     end
@@ -87,11 +86,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
   context "VirtualSwitch" do
     let(:filename) { "test_data/virtual_switch_short_url.xml" }
     it "#event_to_hash2" do
-      expect(described_class.event_to_hash(event, nil)).to(
-        include(
-          :vswitch_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E"
-        )
-      )
+      expect(described_class.event_to_hash(event, nil)).not_to have_key(:host_ems_ref)
     end
   end
 
@@ -100,7 +95,6 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :vlan_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
           :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
         )
       )
@@ -110,22 +104,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
   context "VirtualNetwork" do
     let(:filename) { "test_data/virtual_network_short_url.xml" }
     it "#event_to_hash2" do
-      expect(described_class.event_to_hash(event, nil)).to(
-        include(
-          :vlan_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E"
-        )
-      )
-    end
-  end
-
-  context "Cluster" do
-    let(:filename) { "test_data/cluster.xml" }
-    it "#event_to_hash" do
-      expect(described_class.event_to_hash(event, nil)).to(
-        include(
-          :storage_ems_ref => "c1e50c27-888c-3c4d-8d4a-53a3768ea250"
-        )
-      )
+      expect(described_class.event_to_hash(event, nil)).not_to have_key(:host_ems_ref)
     end
   end
 

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser_spec.rb
@@ -45,7 +45,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
           :vm_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
-          :message      => "Other"
+          :message    => "Other"
         )
       )
     end
@@ -70,7 +70,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
           :vm_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
-          :message      => "Other"
+          :message    => "Other"
         )
       )
     end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_parser_spec.rb
@@ -32,7 +32,8 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
           :vm_ems_ref   => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
-          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
+          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49",
+          :message      => "Other"
         )
       )
     end
@@ -43,7 +44,8 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash2" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :vm_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E"
+          :vm_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
+          :message      => "Other"
         )
       )
     end
@@ -55,7 +57,8 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
           :vm_ems_ref   => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
-          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
+          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49",
+          :message      => "Other"
         )
       )
     end
@@ -66,7 +69,8 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash2" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :vm_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E"
+          :vm_ems_ref => "74CC38E2-C6DD-4B03-A0C6-088F7882EF0E",
+          :message      => "Other"
         )
       )
     end
@@ -77,7 +81,8 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
+          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49",
+          :message      => "Other"
         )
       )
     end
@@ -95,7 +100,8 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49"
+          :host_ems_ref => "e4acf909-6d0b-3c03-b75a-4d8495e5fc49",
+          :message      => "Other"
         )
       )
     end
@@ -113,7 +119,20 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventParser do
     it "#event_to_hash" do
       expect(described_class.event_to_hash(event, nil)).to(
         include(
-          :host_ems_ref => "d47a585d-eaa8-3a54-b4dc-93346276ea37"
+          :host_ems_ref => "d47a585d-eaa8-3a54-b4dc-93346276ea37",
+          :message      => "PoolName"
+        )
+      )
+    end
+  end
+
+  context "UserTask" do
+    let(:filename) { "test_data/template.xml" }
+    it "#event_to_hash" do
+      event.usertask = {"key" => "msgtest"}
+      expect(described_class.event_to_hash(event, nil)).to(
+        include(
+          :message      => "msgtest"
         )
       )
     end


### PR DESCRIPTION
The HMC provider currently records all HMC events in the `event_streams`, resulting in this table growing out of control with a numbers of daily new entries in the order of thousands.

A very large part of these entries are of type INVALID_URI, which only means the cache has been cleared on the HMC side for a given object.

Proposed solution:
- Limit recorded events to CREATE_URI, MODIFY_URI and DELETE_URI
- Fill in message field to have more information on what actually changed
- Downgrade all events from 'critical' level to 'detail'

Event example:
![image](https://user-images.githubusercontent.com/82665100/197196955-73934ccb-3c4e-445e-8141-810a818d2b0b.png)
