### PR TITLE
fix deprecation warning in lazy_find with options

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -489,7 +489,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   def vlan_by_tag(sys_uuid, vswitch_uuid, vlan_id)
     host = persister.hosts.lazy_find(sys_uuid)
     vswitch = persister.host_virtual_switches.lazy_find(:host => host, :uid_ems => vswitch_uuid)
-    persister.lans.lazy_find({:switch => vswitch, :tag => vlan_id}, {:ref => :by_tag})
+    persister.lans.lazy_find({:switch => vswitch, :tag => vlan_id}, :ref => :by_tag)
   end
 
   def build_ethernet_dev(lpar, ent, hardware, controller_type)


### PR DESCRIPTION
A deprecation warning was added in this commit:
https://github.com/ManageIQ/inventory_refresh/commit/e599e73ec5244b83bce38dcb3be90855b0a02f4a
if `lazy_find` is called with a hash for options.
This `lazy_find` call was introduced by PR https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/105.

```
DEPRECATION WARNING: Passing a hash for options is deprecated and will be removed in an upcoming release. (called from vlan_by_tag at /home/runner/work/manageiq-providers-ibm_power_hmc/manageiq-providers-ibm_power_hmc/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb:492)
```