### PR TITLE
hmc groups as vm labels

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -17,6 +17,13 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
     end
   end
 
+  def groups
+    @groups ||= connection.groups.index_by(&:uuid)
+  rescue => e
+    $ibm_power_hmc_log.error("groups query failed: #{e}")
+    raise
+  end
+
   def ssps
     @ssps ||= begin
       connection.ssps

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -237,12 +237,30 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     )
     parse_vm_operating_system(vm, lpar)
     parse_vm_advanced_settings(vm, lpar)
+    parse_vm_labels(vm, lpar)
 
     hardware = parse_vm_hardware(vm, lpar)
     parse_vm_networks(lpar, hardware)
     parse_vm_guest_devices(lpar, hardware)
 
     [vm, hardware]
+  end
+
+  def parse_vm_labels(vm, lpar)
+    # Common code for LPARs and VIOSes.
+    lpar.group_uuids.each do |uuid|
+      next unless collector.groups.key?(uuid)
+
+      group = collector.groups[uuid]
+      persister.vm_and_template_labels.build(
+        :resource    => vm,
+        :name        => group.name,
+        :section     => "labels",
+        :source      => "ibm_power_hmc",
+        :value       => "",
+        :description => group.description
+      )
+    end
   end
 
   def parse_vm_hardware(vm, lpar)

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -33,5 +33,6 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :resource_pools)
     add_collection(infra, :vm_resource_pools)
     add_collection(infra, :parent_blue_folders)
+    add_collection(infra, :vm_and_template_labels)
   end
 end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
@@ -208,6 +208,9 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
       :read_only => true
     )
 
+    expect(vios.labels.count).to eq(1)
+    expect(vios.labels.first.name).to eq("ManageIQ")
+
     expect(vios.host).not_to be_nil
     expect(vios.host.name).to eq("aramis")
 
@@ -268,6 +271,9 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
       :value     => "uncapped",
       :read_only => true
     )
+
+    expect(lpar.labels.count).to eq(1)
+    expect(lpar.labels.first.name).to eq("ManageIQ")
 
     expect(lpar.host).not_to be_nil
     expect(lpar.host.ems_ref).to eq(host_uuid)

--- a/spec/vcr_cassettes/manageiq/providers/ibm_power_hmc/infra_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_power_hmc/infra_manager/refresher.yml
@@ -44,7 +44,7 @@ http_interactions:
             <X-API-Session>xxx</X-API-Session>
         </LogonResponse>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:06 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:11 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/quick/All
@@ -69,7 +69,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '3638'
+      - '3633'
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -77,18 +77,18 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"Description":"Pollux Extension: Ab1-13/16","ConfigurableSystemMemory":262144,"SystemFirmware":"SV860_FW860.30
-        (103)","ConfigurableSystemProcessorUnits":2E+1,"CurrentAvailableSystemProcessorUnits":7.1,"SystemName":"pollux","ManufacturingDefaultConfigurationEnabled":"false","UUID":"d47a585d-eaa8-3a54-b4dc-93346276ea37","InstalledSystemProcessorUnits":2E+1,"IsPowerVMManagementMaster":"false","ActivatedLevel":"103","InstalledSystemMemory":262144,"CapacityOnDemandProcessorCapable":"true","MTMS":"8284-22A*21FD4AV","MaximumPartitions":400,"CurrentAvailableSystemMemory":1.4464E+5,"SystemLocation":"Ab1-17/18","PhysicalSystemAttentionLEDState":"true","ServiceProcessorVersion":"0008000C","State":"operating","MergedReferenceCode":"
+        (103)","ConfigurableSystemProcessorUnits":2E+1,"CurrentAvailableSystemProcessorUnits":7,"SystemName":"pollux","ManufacturingDefaultConfigurationEnabled":"false","UUID":"d47a585d-eaa8-3a54-b4dc-93346276ea37","InstalledSystemProcessorUnits":2E+1,"IsPowerVMManagementMaster":"false","ActivatedLevel":"103","InstalledSystemMemory":262144,"CapacityOnDemandProcessorCapable":"true","MTMS":"8284-22A*21FD4AV","MaximumPartitions":400,"CurrentAvailableSystemMemory":144384,"SystemLocation":"Ab1-17/18","PhysicalSystemAttentionLEDState":"true","ServiceProcessorVersion":"0008000C","State":"operating","MergedReferenceCode":"
         ","IsNotPowerVMManagementMaster":"false","IsClassicHMCManagement":"true","ReferenceCode":"
         ","CapacityOnDemandMemoryCapable":"true","IPAddress":"10.197.64.165","MemoryDefragmentationState":"Not_In_Progress"},{"Description":"","ConfigurableSystemMemory":720896,"SystemFirmware":"SV860_FW860.61
         (185)","ConfigurableSystemProcessorUnits":16,"CurrentAvailableSystemProcessorUnits":9.4,"SystemName":"porthos","ManufacturingDefaultConfigurationEnabled":"false","UUID":"0685d4a6-2021-3044-84e3-59f44e9cc5d7","InstalledSystemProcessorUnits":16,"IsPowerVMManagementMaster":"false","ActivatedLevel":"185","InstalledSystemMemory":720896,"CapacityOnDemandProcessorCapable":"true","MTMS":"8286-42A*103341V","MaximumPartitions":320,"CurrentAvailableSystemMemory":636928,"SystemLocation":"Ab1-9/12","PhysicalSystemAttentionLEDState":"true","ServiceProcessorVersion":"0008000C","State":"operating","MergedReferenceCode":"
         ","IsNotPowerVMManagementMaster":"false","IsClassicHMCManagement":"true","ReferenceCode":"
         ","CapacityOnDemandMemoryCapable":"true","IPAddress":"10.197.64.46","MemoryDefragmentationState":"Not_In_Progress"},{"Description":null,"ConfigurableSystemMemory":0,"SystemFirmware":"_","ConfigurableSystemProcessorUnits":0,"CurrentAvailableSystemProcessorUnits":0,"SystemName":"10.197.65.254","ManufacturingDefaultConfigurationEnabled":"false","UUID":"d2cf855c-cdc7-3851-83fc-d18ef63e7596","InstalledSystemProcessorUnits":0,"IsPowerVMManagementMaster":"false","ActivatedLevel":null,"InstalledSystemMemory":0,"CapacityOnDemandProcessorCapable":"false","MTMS":"0-0*10.197.65.254","MaximumPartitions":null,"CurrentAvailableSystemMemory":0,"SystemLocation":null,"PhysicalSystemAttentionLEDState":"null","ServiceProcessorVersion":null,"State":"no
         connection","MergedReferenceCode":"Connecting 0000","IsNotPowerVMManagementMaster":"false","IsClassicHMCManagement":"true","ReferenceCode":"0000-0000-00000000","CapacityOnDemandMemoryCapable":"false","IPAddress":"10.197.65.254","MemoryDefragmentationState":null},{"Description":"","ConfigurableSystemMemory":524288,"SystemFirmware":"SV860_FW860.61
-        (185)","ConfigurableSystemProcessorUnits":16,"CurrentAvailableSystemProcessorUnits":2.9,"SystemName":"aramis","ManufacturingDefaultConfigurationEnabled":"false","UUID":"e4acf909-6d0b-3c03-b75a-4d8495e5fc49","InstalledSystemProcessorUnits":16,"IsPowerVMManagementMaster":"false","ActivatedLevel":"185","InstalledSystemMemory":524288,"CapacityOnDemandProcessorCapable":"true","MTMS":"8286-42A*214D29V","MaximumPartitions":320,"CurrentAvailableSystemMemory":132352,"SystemLocation":"Ab1-4/7","PhysicalSystemAttentionLEDState":"true","ServiceProcessorVersion":"0008000C","State":"operating","MergedReferenceCode":"
+        (185)","ConfigurableSystemProcessorUnits":16,"CurrentAvailableSystemProcessorUnits":3.9,"SystemName":"aramis","ManufacturingDefaultConfigurationEnabled":"false","UUID":"e4acf909-6d0b-3c03-b75a-4d8495e5fc49","InstalledSystemProcessorUnits":16,"IsPowerVMManagementMaster":"false","ActivatedLevel":"185","InstalledSystemMemory":524288,"CapacityOnDemandProcessorCapable":"true","MTMS":"8286-42A*214D29V","MaximumPartitions":320,"CurrentAvailableSystemMemory":133376,"SystemLocation":"Ab1-4/7","PhysicalSystemAttentionLEDState":"true","ServiceProcessorVersion":"0008000C","State":"operating","MergedReferenceCode":"
         ","IsNotPowerVMManagementMaster":"false","IsClassicHMCManagement":"true","ReferenceCode":"
         ","CapacityOnDemandMemoryCapable":"true","IPAddress":"10.197.64.50","MemoryDefragmentationState":"Not_In_Progress"}]'
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:06 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:11 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37?group=SystemNetwork
@@ -113,7 +113,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '1075635850'
+      - '721374848'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -129,19 +129,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>d47a585d-eaa8-3a54-b4dc-93346276ea37</id>
             <title>ManagedSystem</title>
-            <published>2022-11-16T11:48:21.832+01:00</published>
+            <published>2022-11-17T09:39:28.469+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37?group=SystemNetwork"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1075635850</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">721374848</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=ManagedSystem">
                 <ManagedSystem:ManagedSystem xmlns:ManagedSystem="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>d47a585d-eaa8-3a54-b4dc-93346276ea37</AtomID>
-                    <AtomCreated>1667833157519</AtomCreated>
+                    <AtomCreated>1668602219528</AtomCreated>
                 </Atom>
             </Metadata>
             <ActivatedLevel kxe="false" kb="ROR">103</ActivatedLevel>
@@ -153,6 +153,7 @@ http_interactions:
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/7C5E7B8C-221D-4413-BE31-52002D1C7565" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04" rel="related"/>
             </AssociatedLogicalPartitions>
             <AssociatedReservedStorageDevicePool kxe="false" kb="CUD">
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/ReservedStorageDevicePool/b5eac9f0-9d1c-3058-bf44-4a36570bf0d6" rel="related"/>
@@ -5016,7 +5017,7 @@ http_interactions:
                 <ConfiguredMirroredMemory kxe="false" kb="CUD">0</ConfiguredMirroredMemory>
                 <CurrentAvailableHugePages kxe="false" kb="ROR">0</CurrentAvailableHugePages>
                 <CurrentAvailableMirroredMemory kb="ROR" kxe="false">0</CurrentAvailableMirroredMemory>
-                <CurrentAvailableSystemMemory kb="ROR" kxe="false">144640</CurrentAvailableSystemMemory>
+                <CurrentAvailableSystemMemory kb="ROR" kxe="false">144384</CurrentAvailableSystemMemory>
                 <CurrentLogicalMemoryBlockSize kb="ROR" kxe="false">256</CurrentLogicalMemoryBlockSize>
                 <CurrentMemoryMirroringMode kxe="false" kb="ROR">none</CurrentMemoryMirroringMode>
                 <CurrentMirroredMemory kb="ROR" kxe="false">0</CurrentMirroredMemory>
@@ -5033,12 +5034,12 @@ http_interactions:
                 <MemoryDefragmentationState kb="CUD" kxe="false">Not_In_Progress</MemoryDefragmentationState>
                 <MemoryMirroringState kb="CUD" kxe="false">Off</MemoryMirroringState>
                 <MemoryRegionSize kxe="false" kb="CUD">256</MemoryRegionSize>
-                <MemoryUsedByHypervisor kxe="false" kb="ROR">6912</MemoryUsedByHypervisor>
+                <MemoryUsedByHypervisor kxe="false" kb="ROR">7168</MemoryUsedByHypervisor>
                 <MirrorableMemoryWithDefragmentation kxe="false" kb="ROR">0</MirrorableMemoryWithDefragmentation>
                 <MirrorableMemoryWithoutDefragmentation kxe="false" kb="ROR">0</MirrorableMemoryWithoutDefragmentation>
                 <MirroredMemoryUsedByHypervisor kxe="false" kb="ROR">0</MirroredMemoryUsedByHypervisor>
                 <PendingAvailableHugePages kb="CUD" kxe="false">0</PendingAvailableHugePages>
-                <PendingAvailableSystemMemory kxe="false" kb="CUD">144640</PendingAvailableSystemMemory>
+                <PendingAvailableSystemMemory kxe="false" kb="CUD">144384</PendingAvailableSystemMemory>
                 <PendingLogicalMemoryBlockSize kb="CUD" kxe="false">256</PendingLogicalMemoryBlockSize>
                 <PendingMemoryMirroringMode kxe="false" kb="CUD">none</PendingMemoryMirroringMode>
                 <PendingMemoryRegionSize kb="CUD" kxe="false">256</PendingMemoryRegionSize>
@@ -5052,7 +5053,7 @@ http_interactions:
                     <Atom/>
                 </Metadata>
                 <ConfigurableSystemProcessorUnits kxe="false" kb="ROR">20</ConfigurableSystemProcessorUnits>
-                <CurrentAvailableSystemProcessorUnits kxe="false" kb="ROR">7.1</CurrentAvailableSystemProcessorUnits>
+                <CurrentAvailableSystemProcessorUnits kxe="false" kb="ROR">7</CurrentAvailableSystemProcessorUnits>
                 <CurrentMaximumProcessorsPerAIXOrLinuxPartition kb="ROR" kxe="false">64</CurrentMaximumProcessorsPerAIXOrLinuxPartition>
                 <CurrentMaximumProcessorsPerIBMiPartition kb="ROR" kxe="false">4</CurrentMaximumProcessorsPerIBMiPartition>
                 <CurrentMaximumAllowedProcessorsPerPartition kxe="false" kb="ROR">256</CurrentMaximumAllowedProcessorsPerPartition>
@@ -5068,7 +5069,7 @@ http_interactions:
                 <NumberOfLinuxOnlyProcessorUnits kb="ROR" kxe="false">0</NumberOfLinuxOnlyProcessorUnits>
                 <NumberOfLinuxOrVIOSOnlyProcessorUnits ksv="V1_3_0" kxe="false" kb="ROR">0</NumberOfLinuxOrVIOSOnlyProcessorUnits>
                 <NumberOfVirtualIOServerProcessorUnits kb="ROR" kxe="false">0</NumberOfVirtualIOServerProcessorUnits>
-                <PendingAvailableSystemProcessorUnits kb="CUD" kxe="false">7.1</PendingAvailableSystemProcessorUnits>
+                <PendingAvailableSystemProcessorUnits kb="CUD" kxe="false">7</PendingAvailableSystemProcessorUnits>
                 <SharedProcessorPoolCount kb="ROR" kxe="false">64</SharedProcessorPoolCount>
                 <SupportedPartitionProcessorCompatibilityModes kb="ROR" kxe="false">default</SupportedPartitionProcessorCompatibilityModes>
                 <SupportedPartitionProcessorCompatibilityModes kb="ROR" kxe="false">POWER6</SupportedPartitionProcessorCompatibilityModes>
@@ -5178,7 +5179,7 @@ http_interactions:
             <ServiceProcessorVersion kxe="false" kb="ROR">0008000C</ServiceProcessorVersion>
             <State kb="ROR" kxe="false">operating</State>
             <SystemName kb="CUR" kxe="false">pollux</SystemName>
-            <SystemTime kb="ROR" kxe="true">1668590227117</SystemTime>
+            <SystemTime kb="ROR" kxe="true">1668668892000</SystemTime>
             <VirtualSystemAttentionLEDState kb="UOD" kxe="false">true</VirtualSystemAttentionLEDState>
             <SystemMigrationInformation kxe="false" kb="ROR" schemaVersion="V1_5_0">
                 <Metadata>
@@ -5211,7 +5212,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:07 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:12 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7?group=SystemNetwork
@@ -5252,7 +5253,7 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>0685d4a6-2021-3044-84e3-59f44e9cc5d7</id>
             <title>ManagedSystem</title>
-            <published>2022-11-16T11:48:23.157+01:00</published>
+            <published>2022-11-17T09:39:29.663+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7?group=SystemNetwork"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
@@ -7545,7 +7546,7 @@ http_interactions:
             <ServiceProcessorVersion kxe="false" kb="ROR">0008000C</ServiceProcessorVersion>
             <State kb="ROR" kxe="false">operating</State>
             <SystemName kb="CUR" kxe="false">porthos</SystemName>
-            <SystemTime kb="ROR" kxe="true">1668589906503</SystemTime>
+            <SystemTime kb="ROR" kxe="true">1668668570459</SystemTime>
             <VirtualSystemAttentionLEDState kb="UOD" kxe="false">true</VirtualSystemAttentionLEDState>
             <SystemMigrationInformation kxe="false" kb="ROR" schemaVersion="V1_5_0">
                 <Metadata>
@@ -7578,7 +7579,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:08 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:13 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49?group=SystemNetwork
@@ -7603,7 +7604,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '91987870'
+      - '1246026808'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -7619,24 +7620,23 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>e4acf909-6d0b-3c03-b75a-4d8495e5fc49</id>
             <title>ManagedSystem</title>
-            <published>2022-11-16T11:48:24.374+01:00</published>
+            <published>2022-11-17T09:39:30.511+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49?group=SystemNetwork"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">91987870</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1246026808</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=ManagedSystem">
                 <ManagedSystem:ManagedSystem xmlns:ManagedSystem="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>e4acf909-6d0b-3c03-b75a-4d8495e5fc49</AtomID>
-                    <AtomCreated>1667833157519</AtomCreated>
+                    <AtomCreated>1668673997584</AtomCreated>
                 </Atom>
             </Metadata>
             <ActivatedLevel kxe="false" kb="ROR">185</ActivatedLevel>
             <AssociatedLogicalPartitions kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/0611F373-2215-4103-9D05-8E162E67ADBD" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C" rel="related"/>
@@ -7648,13 +7648,13 @@ http_interactions:
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/3BD7BF62-1ED0-4AF1-A605-D8E6A9FACDD9" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/2D5E4DBF-5294-493F-9F0C-A1D4776F10D2" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/18CF2B4F-BE3D-4CF4-A28C-1483D89DCB9F" rel="related"/>
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/6F67D796-80BA-457F-9E81-2B307A484294" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/7D1DAADD-36EF-4D78-95EE-1E9B8C656DA1" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/40381833-1012-44B9-8455-E2D6B9BD00EE" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257" rel="related"/>
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/4B2A17C0-0FB1-4B3E-8354-94A6D25380D1" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507" rel="related"/>
             </AssociatedLogicalPartitions>
             <AssociatedSystemCapabilities kxe="false" kb="CUD" schemaVersion="V1_5_0">
                 <Metadata>
@@ -10476,7 +10476,7 @@ http_interactions:
                 <ConfiguredMirroredMemory kxe="false" kb="CUD">0</ConfiguredMirroredMemory>
                 <CurrentAvailableHugePages kxe="false" kb="ROR">0</CurrentAvailableHugePages>
                 <CurrentAvailableMirroredMemory kb="ROR" kxe="false">0</CurrentAvailableMirroredMemory>
-                <CurrentAvailableSystemMemory kb="ROR" kxe="false">132352</CurrentAvailableSystemMemory>
+                <CurrentAvailableSystemMemory kb="ROR" kxe="false">133376</CurrentAvailableSystemMemory>
                 <CurrentLogicalMemoryBlockSize kb="ROR" kxe="false">256</CurrentLogicalMemoryBlockSize>
                 <CurrentMemoryMirroringMode kxe="false" kb="ROR">none</CurrentMemoryMirroringMode>
                 <CurrentMirroredMemory kb="ROR" kxe="false">0</CurrentMirroredMemory>
@@ -10498,7 +10498,7 @@ http_interactions:
                 <MirrorableMemoryWithoutDefragmentation kxe="false" kb="ROR">0</MirrorableMemoryWithoutDefragmentation>
                 <MirroredMemoryUsedByHypervisor kxe="false" kb="ROR">0</MirroredMemoryUsedByHypervisor>
                 <PendingAvailableHugePages kb="CUD" kxe="false">0</PendingAvailableHugePages>
-                <PendingAvailableSystemMemory kxe="false" kb="CUD">132352</PendingAvailableSystemMemory>
+                <PendingAvailableSystemMemory kxe="false" kb="CUD">133376</PendingAvailableSystemMemory>
                 <PendingLogicalMemoryBlockSize kb="CUD" kxe="false">256</PendingLogicalMemoryBlockSize>
                 <PendingMemoryMirroringMode kxe="false" kb="CUD">none</PendingMemoryMirroringMode>
                 <PendingMemoryRegionSize kb="CUD" kxe="false">256</PendingMemoryRegionSize>
@@ -10509,7 +10509,7 @@ http_interactions:
                     <Atom/>
                 </Metadata>
                 <ConfigurableSystemProcessorUnits kxe="false" kb="ROR">16</ConfigurableSystemProcessorUnits>
-                <CurrentAvailableSystemProcessorUnits kxe="false" kb="ROR">2.9</CurrentAvailableSystemProcessorUnits>
+                <CurrentAvailableSystemProcessorUnits kxe="false" kb="ROR">3.9</CurrentAvailableSystemProcessorUnits>
                 <CurrentMaximumProcessorsPerAIXOrLinuxPartition kb="ROR" kxe="false">64</CurrentMaximumProcessorsPerAIXOrLinuxPartition>
                 <CurrentMaximumProcessorsPerIBMiPartition kb="ROR" kxe="false">64</CurrentMaximumProcessorsPerIBMiPartition>
                 <CurrentMaximumAllowedProcessorsPerPartition kxe="false" kb="ROR">256</CurrentMaximumAllowedProcessorsPerPartition>
@@ -10525,7 +10525,7 @@ http_interactions:
                 <NumberOfLinuxOnlyProcessorUnits kb="ROR" kxe="false">0</NumberOfLinuxOnlyProcessorUnits>
                 <NumberOfLinuxOrVIOSOnlyProcessorUnits ksv="V1_3_0" kxe="false" kb="ROR">0</NumberOfLinuxOrVIOSOnlyProcessorUnits>
                 <NumberOfVirtualIOServerProcessorUnits kb="ROR" kxe="false">0</NumberOfVirtualIOServerProcessorUnits>
-                <PendingAvailableSystemProcessorUnits kb="CUD" kxe="false">2.9</PendingAvailableSystemProcessorUnits>
+                <PendingAvailableSystemProcessorUnits kb="CUD" kxe="false">3.9</PendingAvailableSystemProcessorUnits>
                 <SharedProcessorPoolCount kb="ROR" kxe="false">64</SharedProcessorPoolCount>
                 <SupportedPartitionProcessorCompatibilityModes kb="ROR" kxe="false">default</SupportedPartitionProcessorCompatibilityModes>
                 <SupportedPartitionProcessorCompatibilityModes kb="ROR" kxe="false">POWER6</SupportedPartitionProcessorCompatibilityModes>
@@ -10610,8 +10610,8 @@ http_interactions:
                 <AvailableVirtualTrustedPlatformModulePartitions ksv="V1_3_0" kb="ROO" kxe="false">60</AvailableVirtualTrustedPlatformModulePartitions>
             </AssociatedSystemSecurity>
             <AssociatedVirtualIOServers kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/0A0DC7D2-42B2-45BD-B63F-22C5290A103C" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/4494A109-8B0F-4923-8BCB-71CE8D9E5D18" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E" rel="related"/>
             </AssociatedVirtualIOServers>
@@ -10637,7 +10637,7 @@ http_interactions:
             <ServiceProcessorVersion kxe="false" kb="ROR">0008000C</ServiceProcessorVersion>
             <State kb="ROR" kxe="false">operating</State>
             <SystemName kb="CUR" kxe="false">aramis</SystemName>
-            <SystemTime kb="ROR" kxe="true">1668588969322</SystemTime>
+            <SystemTime kb="ROR" kxe="true">1668667633176</SystemTime>
             <VirtualSystemAttentionLEDState kb="UOD" kxe="false">true</VirtualSystemAttentionLEDState>
             <SystemMigrationInformation kxe="false" kb="ROR" schemaVersion="V1_5_0">
                 <Metadata>
@@ -10670,7 +10670,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:09 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:14 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/quick/All
@@ -10706,7 +10706,7 @@ http_interactions:
         ","PartitionID":8,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":"true","APICapable":"true","PartitionName":"polluxios2","IsVirtualServiceAttentionLEDOn":"false","RMCState":"active","AllocatedVirtualProcessors":2,"CurrentMemory":4096,"HasDedicatedProcessors":"false","PartitionState":"running","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37","ResourceMonitoringIPAddress":"10.197.64.195","ReferenceCode":"","CurrentProcessingUnits":0.2,"SharingMode":"uncapped","UUID":"1ABB7000-4A15-4749-9EAE-CD0A0827CDFE"},{"CurrentProcessors":null,"OperatingSystemVersion":"VIOS
         2.2.5.10 ","PartitionID":2,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":"true","APICapable":"true","PartitionName":"polluxios","IsVirtualServiceAttentionLEDOn":"false","RMCState":"active","AllocatedVirtualProcessors":2,"CurrentMemory":5.12E+3,"HasDedicatedProcessors":"false","PartitionState":"running","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37","ResourceMonitoringIPAddress":"10.197.64.167","ReferenceCode":"","CurrentProcessingUnits":1,"SharingMode":"uncapped","UUID":"0D323064-36E2-455A-AB06-46BD079AD545"}]'
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:10 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:15 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer/quick/All
@@ -10748,7 +10748,7 @@ http_interactions:
         3.1.0.11 ","PartitionID":1,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":"true","APICapable":"true","PartitionName":"porthosios","IsVirtualServiceAttentionLEDOn":"false","RMCState":"active","AllocatedVirtualProcessors":null,"CurrentMemory":8192,"HasDedicatedProcessors":"true","PartitionState":"running","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7","ResourceMonitoringIPAddress":"10.197.64.77","ReferenceCode":"","CurrentProcessingUnits":null,"SharingMode":"sre
         idle proces","UUID":"4154B185-22EB-4D16-B1F4-D9F714496C98"}]'
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:10 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:15 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/quick/All
@@ -10780,17 +10780,17 @@ http_interactions:
       - no-cache="set-cookie, set-cookie2"
     body:
       encoding: UTF-8
-      string: '[{"CurrentProcessors":null,"OperatingSystemVersion":"VIOS ","PartitionID":3,"PartitionType":"Virtual
-        IO Server","VirtualIOServerLicenseAccepted":null,"APICapable":"false","PartitionName":"aramis-vios2","IsVirtualServiceAttentionLEDOn":"false","RMCState":"inactive","AllocatedVirtualProcessors":1,"CurrentMemory":1.024E+4,"HasDedicatedProcessors":"false","PartitionState":"not
-        activated","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49","ResourceMonitoringIPAddress":"10.197.64.116","ReferenceCode":"00000000","CurrentProcessingUnits":0.4,"SharingMode":"uncapped","UUID":"785FB584-AA40-460D-8803-A38AA0271030"},{"CurrentProcessors":null,"OperatingSystemVersion":"VIOS
-        ","PartitionID":5,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":null,"APICapable":"false","PartitionName":"aramis-vios3","IsVirtualServiceAttentionLEDOn":"false","RMCState":"inactive","AllocatedVirtualProcessors":1,"CurrentMemory":8192,"HasDedicatedProcessors":"false","PartitionState":"not
+      string: '[{"CurrentProcessors":null,"OperatingSystemVersion":"VIOS ","PartitionID":5,"PartitionType":"Virtual
+        IO Server","VirtualIOServerLicenseAccepted":null,"APICapable":"false","PartitionName":"aramis-vios3","IsVirtualServiceAttentionLEDOn":"false","RMCState":"inactive","AllocatedVirtualProcessors":1,"CurrentMemory":8192,"HasDedicatedProcessors":"false","PartitionState":"not
         activated","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49","ResourceMonitoringIPAddress":"10.197.64.42","ReferenceCode":"00000000","CurrentProcessingUnits":0.4,"SharingMode":"uncapped","UUID":"0A0DC7D2-42B2-45BD-B63F-22C5290A103C"},{"CurrentProcessors":null,"OperatingSystemVersion":"VIOS
+        ","PartitionID":3,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":null,"APICapable":"false","PartitionName":"aramis-vios2","IsVirtualServiceAttentionLEDOn":"false","RMCState":"inactive","AllocatedVirtualProcessors":1,"CurrentMemory":1.024E+4,"HasDedicatedProcessors":"false","PartitionState":"not
+        activated","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49","ResourceMonitoringIPAddress":"10.197.64.116","ReferenceCode":"00000000","CurrentProcessingUnits":0.4,"SharingMode":"uncapped","UUID":"785FB584-AA40-460D-8803-A38AA0271030"},{"CurrentProcessors":null,"OperatingSystemVersion":"VIOS
         ","PartitionID":2,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":null,"APICapable":"false","PartitionName":"aramis-vios1","IsVirtualServiceAttentionLEDOn":"false","RMCState":"inactive","AllocatedVirtualProcessors":1,"CurrentMemory":1.024E+4,"HasDedicatedProcessors":"false","PartitionState":"not
         activated","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49","ResourceMonitoringIPAddress":"10.197.64.107","ReferenceCode":"00000000","CurrentProcessingUnits":0.4,"SharingMode":"uncapped","UUID":"4494A109-8B0F-4923-8BCB-71CE8D9E5D18"},{"CurrentProcessors":2,"OperatingSystemVersion":"VIOS
         3.1.0.11 ","PartitionID":1,"PartitionType":"Virtual IO Server","VirtualIOServerLicenseAccepted":"true","APICapable":"true","PartitionName":"aramisios","IsVirtualServiceAttentionLEDOn":"false","RMCState":"active","AllocatedVirtualProcessors":null,"CurrentMemory":8192,"HasDedicatedProcessors":"true","PartitionState":"running","AssociatedManagedSystem":"https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49","ResourceMonitoringIPAddress":"10.197.64.55","ReferenceCode":"","CurrentProcessingUnits":null,"SharingMode":"sre
         idle proces","UUID":"4165A16F-0766-40F3-B9E2-7272E1910F2E"}]'
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:10 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:15 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole
@@ -10830,14 +10830,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>c4db243e-3107-3382-876e-90113f45b44e</id>
-            <updated>2022-11-16T11:48:25.074+01:00</updated>
+            <updated>2022-11-17T09:39:31.131+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>67c67e9a-c027-3a3d-9399-ebe6aa14e12e</id>
                 <title>ManagementConsole</title>
-                <published>2022-11-16T11:48:25.491+01:00</published>
+                <published>2022-11-17T09:39:31.470+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -10992,7 +10992,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:10 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:15 GMT
 - request:
     method: put
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner
@@ -11036,10 +11036,10 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>4bea01f0-910d-4b88-8084-3c3ef859493d</id>
+            <id>a61958f6-5899-4fee-bad2-ead6984faaf9</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:25.600+01:00</published>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035256"/>
+            <published>2022-11-17T09:39:31.546+01:00</published>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035298"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
@@ -11050,7 +11050,7 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035256</JobID>
+            <JobID kxe="false" kb="ROR">1667807035298</JobID>
             <TimeStarted kxe="false" kb="ROR">0</TimeStarted>
             <TimeCompleted kxe="false" kb="ROR">0</TimeCompleted>
             <Status kxe="false" kb="ROR">NOT_STARTED</Status>
@@ -11099,10 +11099,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:10 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:15 GMT
 - request:
     method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035256
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035298
     body:
       encoding: US-ASCII
       string: ''
@@ -11126,7 +11126,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '287135184'
+      - '1899230524'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -11140,11 +11140,11 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>b4365e9c-73d8-337c-b35b-738f971ac9e7</id>
+            <id>d2061891-b2d8-35d7-8583-addb35337634</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:25.645+01:00</published>
-            <link rel="SELF" href="nulljobs/1667807035256"/>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035256/b7d1b851-ab65-4395-bd42-346340a734f4"/>
+            <published>2022-11-17T09:39:31.593+01:00</published>
+            <link rel="SELF" href="nulljobs/1667807035298"/>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035298/f4b4b494-8bc1-47a5-aa9d-f717d747d62d"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
@@ -11156,8 +11156,8 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035256</JobID>
-            <TimeStarted kxe="false" kb="ROR">1668595705600</TimeStarted>
+            <JobID kxe="false" kb="ROR">1667807035298</JobID>
+            <TimeStarted kxe="false" kb="ROR">1668674371546</TimeStarted>
             <TimeCompleted kxe="false" kb="ROR">0</TimeCompleted>
             <Status kxe="false" kb="ROR">RUNNING</Status>
             <JobRequestInstance kxe="false" kb="ROR" schemaVersion="V1_5_0">
@@ -11205,10 +11205,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:11 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:15 GMT
 - request:
     method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035256
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035298
     body:
       encoding: US-ASCII
       string: ''
@@ -11232,7 +11232,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-1482119268"
+      - "-2010881562"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -11246,11 +11246,11 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>b4365e9c-73d8-337c-b35b-738f971ac9e7</id>
+            <id>d2061891-b2d8-35d7-8583-addb35337634</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:27.699+01:00</published>
-            <link rel="SELF" href="nulljobs/1667807035256"/>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035256/738a4eec-c069-46b0-9c80-7e0df1784210"/>
+            <published>2022-11-17T09:39:33.646+01:00</published>
+            <link rel="SELF" href="nulljobs/1667807035298"/>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035298/f8285bc5-d73f-4c2a-9997-6c1ffd00a4e7"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
@@ -11262,9 +11262,9 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035256</JobID>
-            <TimeStarted kxe="false" kb="ROR">1668595705600</TimeStarted>
-            <TimeCompleted kxe="false" kb="ROR">1668595705678</TimeCompleted>
+            <JobID kxe="false" kb="ROR">1667807035298</JobID>
+            <TimeStarted kxe="false" kb="ROR">1668674371546</TimeStarted>
+            <TimeCompleted kxe="false" kb="ROR">1668674371620</TimeCompleted>
             <Status kxe="false" kb="ROR">COMPLETED_OK</Status>
             <JobRequestInstance kxe="false" kb="ROR" schemaVersion="V1_5_0">
                 <Metadata>
@@ -11328,10 +11328,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:17 GMT
 - request:
     method: delete
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035256
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035298
     body:
       encoding: US-ASCII
       string: ''
@@ -11364,7 +11364,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:17 GMT
 - request:
     method: put
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner
@@ -11408,10 +11408,10 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>1870a498-c2c9-41aa-9b0d-6fa3bf21a74e</id>
+            <id>aa373660-79a6-4261-9fbb-ebb03b730c2e</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:27.834+01:00</published>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035257"/>
+            <published>2022-11-17T09:39:33.793+01:00</published>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035299"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
@@ -11422,7 +11422,7 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035257</JobID>
+            <JobID kxe="false" kb="ROR">1667807035299</JobID>
             <TimeStarted kxe="false" kb="ROR">0</TimeStarted>
             <TimeCompleted kxe="false" kb="ROR">0</TimeCompleted>
             <Status kxe="false" kb="ROR">NOT_STARTED</Status>
@@ -11471,10 +11471,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:18 GMT
 - request:
     method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035257
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035299
     body:
       encoding: US-ASCII
       string: ''
@@ -11498,7 +11498,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '1512868988'
+      - "-1868053419"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -11512,11 +11512,11 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>f82cf920-b687-3412-a317-399391c8d6dc</id>
+            <id>466d51e3-2451-3ba2-8050-1b7ac1eb6b91</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:27.883+01:00</published>
-            <link rel="SELF" href="nulljobs/1667807035257"/>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035257/c8dd4454-bcef-4274-88fb-2865d8a530d8"/>
+            <published>2022-11-17T09:39:33.840+01:00</published>
+            <link rel="SELF" href="nulljobs/1667807035299"/>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035299/ee370081-7303-4c31-a948-9f8f31802642"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
@@ -11528,8 +11528,8 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035257</JobID>
-            <TimeStarted kxe="false" kb="ROR">1668595707834</TimeStarted>
+            <JobID kxe="false" kb="ROR">1667807035299</JobID>
+            <TimeStarted kxe="false" kb="ROR">1668674373793</TimeStarted>
             <TimeCompleted kxe="false" kb="ROR">0</TimeCompleted>
             <Status kxe="false" kb="ROR">RUNNING</Status>
             <JobRequestInstance kxe="false" kb="ROR" schemaVersion="V1_5_0">
@@ -11577,10 +11577,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:18 GMT
 - request:
     method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035257
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035299
     body:
       encoding: US-ASCII
       string: ''
@@ -11604,7 +11604,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '613134835'
+      - "-1860068738"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -11618,11 +11618,11 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>f82cf920-b687-3412-a317-399391c8d6dc</id>
+            <id>466d51e3-2451-3ba2-8050-1b7ac1eb6b91</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:29.936+01:00</published>
-            <link rel="SELF" href="nulljobs/1667807035257"/>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035257/f21d48e6-999c-4b68-bda8-d22c81993d70"/>
+            <published>2022-11-17T09:39:35.893+01:00</published>
+            <link rel="SELF" href="nulljobs/1667807035299"/>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035299/d285728e-7558-4199-aa82-00698b33b323"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
@@ -11634,9 +11634,9 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035257</JobID>
-            <TimeStarted kxe="false" kb="ROR">1668595707834</TimeStarted>
-            <TimeCompleted kxe="false" kb="ROR">1668595707886</TimeCompleted>
+            <JobID kxe="false" kb="ROR">1667807035299</JobID>
+            <TimeStarted kxe="false" kb="ROR">1668674373793</TimeStarted>
+            <TimeCompleted kxe="false" kb="ROR">1668674373856</TimeCompleted>
             <Status kxe="false" kb="ROR">COMPLETED_OK</Status>
             <JobRequestInstance kxe="false" kb="ROR" schemaVersion="V1_5_0">
                 <Metadata>
@@ -11700,10 +11700,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:20 GMT
 - request:
     method: delete
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035257
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035299
     body:
       encoding: US-ASCII
       string: ''
@@ -11736,7 +11736,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:20 GMT
 - request:
     method: put
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner
@@ -11780,10 +11780,10 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>a224ae10-0957-4c05-a4d1-68593a6b6b10</id>
+            <id>9acfa502-2e3f-4f49-9719-77b3ee6f7118</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:30.065+01:00</published>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035258"/>
+            <published>2022-11-17T09:39:35.983+01:00</published>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035300"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
@@ -11794,7 +11794,7 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035258</JobID>
+            <JobID kxe="false" kb="ROR">1667807035300</JobID>
             <TimeStarted kxe="false" kb="ROR">0</TimeStarted>
             <TimeCompleted kxe="false" kb="ROR">0</TimeCompleted>
             <Status kxe="false" kb="ROR">NOT_STARTED</Status>
@@ -11843,10 +11843,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:20 GMT
 - request:
     method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035258
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035300
     body:
       encoding: US-ASCII
       string: ''
@@ -11870,7 +11870,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-1843511748"
+      - "-46825252"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -11884,11 +11884,11 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>1e78e985-8bcf-30e4-a75b-a1280a510fcb</id>
+            <id>cc314951-1c8c-3608-bd39-7643e08f794e</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:30.107+01:00</published>
-            <link rel="SELF" href="nulljobs/1667807035258"/>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035258/912d8b39-eda6-48c3-b512-7ca6491c6bf7"/>
+            <published>2022-11-17T09:39:36.030+01:00</published>
+            <link rel="SELF" href="nulljobs/1667807035300"/>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035300/b4b686b5-3583-48b6-89f5-b373e6bf8d93"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
@@ -11900,8 +11900,8 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035258</JobID>
-            <TimeStarted kxe="false" kb="ROR">1668595710065</TimeStarted>
+            <JobID kxe="false" kb="ROR">1667807035300</JobID>
+            <TimeStarted kxe="false" kb="ROR">1668674375983</TimeStarted>
             <TimeCompleted kxe="false" kb="ROR">0</TimeCompleted>
             <Status kxe="false" kb="ROR">RUNNING</Status>
             <JobRequestInstance kxe="false" kb="ROR" schemaVersion="V1_5_0">
@@ -11949,10 +11949,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:20 GMT
 - request:
     method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035258
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035300
     body:
       encoding: US-ASCII
       string: ''
@@ -11976,7 +11976,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '2019893428'
+      - "-1099449480"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -11990,11 +11990,11 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>1e78e985-8bcf-30e4-a75b-a1280a510fcb</id>
+            <id>cc314951-1c8c-3608-bd39-7643e08f794e</id>
             <title>JobResponse</title>
-            <published>2022-11-16T11:48:32.160+01:00</published>
-            <link rel="SELF" href="nulljobs/1667807035258"/>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035258/ac3bd228-58f1-4056-8c26-8fe073ff0475"/>
+            <published>2022-11-17T09:39:38.085+01:00</published>
+            <link rel="SELF" href="nulljobs/1667807035300"/>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035300/77b88cdd-6e7e-4976-9721-26c4d47f3606"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
@@ -12006,9 +12006,9 @@ http_interactions:
             </Metadata>
             <RequestURL kb="ROR" kxe="false" href="ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e/do/CLIRunner" rel="via" title="The URL to which the JobRequest was submitted."/>
             <TargetUuid kxe="false" kb="ROR">67c67e9a-c027-3a3d-9399-ebe6aa14e12e</TargetUuid>
-            <JobID kxe="false" kb="ROR">1667807035258</JobID>
-            <TimeStarted kxe="false" kb="ROR">1668595710065</TimeStarted>
-            <TimeCompleted kxe="false" kb="ROR">1668595710123</TimeCompleted>
+            <JobID kxe="false" kb="ROR">1667807035300</JobID>
+            <TimeStarted kxe="false" kb="ROR">1668674375983</TimeStarted>
+            <TimeCompleted kxe="false" kb="ROR">1668674376039</TimeCompleted>
             <Status kxe="false" kb="ROR">COMPLETED_OK</Status>
             <JobRequestInstance kxe="false" kb="ROR" schemaVersion="V1_5_0">
                 <Metadata>
@@ -12072,10 +12072,10 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:17 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: delete
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035258
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/jobs/1667807035300
     body:
       encoding: US-ASCII
       string: ''
@@ -12108,7 +12108,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:17 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/pcm/preferences
@@ -12143,16 +12143,16 @@ http_interactions:
       string: |2
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>62e748a5-6b3c-45b4-bacb-5453b73f80a8</id>
+            <id>5b33140d-cc12-4637-bd65-f0fea62c5c62</id>
             <title type="text">Performance and Capacity Monitoring Preferences</title>
             <subtitle type="text"/>
             <link rel="self" href="https://ibm-power-hmc-hostname:12443/rest/api/pcm/preferences"/>
             <generator uri="IBM Power Systems Management Console" version="1"/>
             <entry>
-                <id>da1637f1-cd7b-4b6a-85ce-3909eaecef98</id>
-                <updated>2022-11-16T11:48:32.411+01:00</updated>
+                <id>489b91a7-951f-42bb-a099-996209c24ffd</id>
+                <updated>2022-11-17T09:39:38.382+01:00</updated>
                 <title type="text">Performance and Capacity Monitoring Preferences</title>
-                <published>2022-11-16T11:48:32.411+01:00</published>
+                <published>2022-11-17T09:39:38.382+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -12171,7 +12171,7 @@ http_interactions:
                 <Metadata>
                     <Atom>
                         <AtomID>e4acf909-6d0b-3c03-b75a-4d8495e5fc49</AtomID>
-                        <AtomCreated>1668595712410</AtomCreated>
+                        <AtomCreated>1668674378381</AtomCreated>
                     </Atom>
                 </Metadata>
                 <SystemName kxe="false" kb="ROR">aramis</SystemName>
@@ -12194,7 +12194,7 @@ http_interactions:
                 <Metadata>
                     <Atom>
                         <AtomID>d47a585d-eaa8-3a54-b4dc-93346276ea37</AtomID>
-                        <AtomCreated>1668595712410</AtomCreated>
+                        <AtomCreated>1668674378381</AtomCreated>
                     </Atom>
                 </Metadata>
                 <SystemName kxe="false" kb="ROR">pollux</SystemName>
@@ -12217,7 +12217,7 @@ http_interactions:
                 <Metadata>
                     <Atom>
                         <AtomID>0685d4a6-2021-3044-84e3-59f44e9cc5d7</AtomID>
-                        <AtomCreated>1668595712410</AtomCreated>
+                        <AtomCreated>1668674378382</AtomCreated>
                     </Atom>
                 </Metadata>
                 <SystemName kxe="false" kb="ROR">porthos</SystemName>
@@ -12241,7 +12241,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:17 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualSwitch
@@ -12281,14 +12281,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>10ee6215-65fc-3dc3-8cc6-f092a7a5e58b</id>
-            <updated>2022-11-16T11:48:32.464+01:00</updated>
+            <updated>2022-11-17T09:39:38.443+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualSwitch"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>11b61c12-7a1b-306b-a8c2-3772ea64ea6a</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.472+01:00</published>
+                <published>2022-11-17T09:39:38.451+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualSwitch/11b61c12-7a1b-306b-a8c2-3772ea64ea6a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12314,7 +12314,7 @@ http_interactions:
             <entry>
                 <id>0f7592e9-5f09-3d6b-8a2e-57ea3b7babc6</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.472+01:00</published>
+                <published>2022-11-17T09:39:38.452+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualSwitch/0f7592e9-5f09-3d6b-8a2e-57ea3b7babc6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12342,7 +12342,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:17 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualSwitch
@@ -12382,14 +12382,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>8f059519-bdff-30d6-b724-8c801853d1ae</id>
-            <updated>2022-11-16T11:48:32.523+01:00</updated>
+            <updated>2022-11-17T09:39:38.505+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualSwitch"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>6ce888d1-3e2a-3793-a791-5a8fb311005b</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.531+01:00</published>
+                <published>2022-11-17T09:39:38.513+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualSwitch/6ce888d1-3e2a-3793-a791-5a8fb311005b"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12415,7 +12415,7 @@ http_interactions:
             <entry>
                 <id>7e53ca7d-a16e-3154-9ee3-0add2f16fed2</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.532+01:00</published>
+                <published>2022-11-17T09:39:38.514+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualSwitch/7e53ca7d-a16e-3154-9ee3-0add2f16fed2"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12441,7 +12441,7 @@ http_interactions:
             <entry>
                 <id>3d4f918d-3af0-3afc-95f0-5a170be5a2c6</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.532+01:00</published>
+                <published>2022-11-17T09:39:38.514+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualSwitch/3d4f918d-3af0-3afc-95f0-5a170be5a2c6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12463,7 +12463,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:17 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch
@@ -12503,14 +12503,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>cd73bb3a-22f7-3c68-b50e-b0da357ec15f</id>
-            <updated>2022-11-16T11:48:32.585+01:00</updated>
+            <updated>2022-11-17T09:39:38.572+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>f1e69d99-e617-3c5a-acd6-8b2f1b72ff48</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.592+01:00</published>
+                <published>2022-11-17T09:39:38.580+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12537,7 +12537,7 @@ http_interactions:
             <entry>
                 <id>f8cdaae1-5a3f-3667-a474-184cf9cb0b68</id>
                 <title>VirtualSwitch</title>
-                <published>2022-11-16T11:48:32.593+01:00</published>
+                <published>2022-11-17T09:39:38.581+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f8cdaae1-5a3f-3667-a474-184cf9cb0b68"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12562,7 +12562,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:17 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork
@@ -12602,14 +12602,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>ea88e930-7e4e-3439-afb2-e7961f6de6b6</id>
-            <updated>2022-11-16T11:48:32.642+01:00</updated>
+            <updated>2022-11-17T09:39:38.644+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>25ff0cf9-521e-3667-84f1-0ee2242ba4d8</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.694+01:00</published>
+                <published>2022-11-17T09:39:38.695+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork/25ff0cf9-521e-3667-84f1-0ee2242ba4d8"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12634,7 +12634,7 @@ http_interactions:
             <entry>
                 <id>271a3aed-4e54-37d1-aab0-8d6e36f0c795</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.695+01:00</published>
+                <published>2022-11-17T09:39:38.696+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork/271a3aed-4e54-37d1-aab0-8d6e36f0c795"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12659,7 +12659,7 @@ http_interactions:
             <entry>
                 <id>7ffdc0ed-cbcd-3e28-ae59-0e896613fd31</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.696+01:00</published>
+                <published>2022-11-17T09:39:38.697+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork/7ffdc0ed-cbcd-3e28-ae59-0e896613fd31"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12684,7 +12684,7 @@ http_interactions:
             <entry>
                 <id>d5d8a713-5ece-332a-8640-6e68fa219fc1</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.696+01:00</published>
+                <published>2022-11-17T09:39:38.698+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork/d5d8a713-5ece-332a-8640-6e68fa219fc1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12709,7 +12709,7 @@ http_interactions:
             <entry>
                 <id>685360e6-d82f-39b4-ab96-3e6b8641d373</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.697+01:00</published>
+                <published>2022-11-17T09:39:38.698+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork/685360e6-d82f-39b4-ab96-3e6b8641d373"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12733,7 +12733,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:18 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:22 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualNetwork
@@ -12773,14 +12773,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>711615ad-465c-3009-8dd1-3f0ea0e49371</id>
-            <updated>2022-11-16T11:48:32.753+01:00</updated>
+            <updated>2022-11-17T09:39:38.763+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualNetwork"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>2d06c6f5-d5da-375f-b087-eb914a900fec</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.765+01:00</published>
+                <published>2022-11-17T09:39:38.775+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualNetwork/2d06c6f5-d5da-375f-b087-eb914a900fec"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12805,7 +12805,7 @@ http_interactions:
             <entry>
                 <id>9df39b02-d3da-37c7-91e8-143c6401a634</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.766+01:00</published>
+                <published>2022-11-17T09:39:38.776+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualNetwork/9df39b02-d3da-37c7-91e8-143c6401a634"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12829,7 +12829,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:18 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:23 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork
@@ -12869,14 +12869,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>7d06cc03-1ce2-3a5d-8606-d4b1fcb93c37</id>
-            <updated>2022-11-16T11:48:32.814+01:00</updated>
+            <updated>2022-11-17T09:39:38.826+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>7666d43c-8da4-3bb1-a063-6bdab8a87a18</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.868+01:00</published>
+                <published>2022-11-17T09:39:38.880+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/7666d43c-8da4-3bb1-a063-6bdab8a87a18"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12901,7 +12901,7 @@ http_interactions:
             <entry>
                 <id>9ff9d880-6b48-3b3c-982b-bb7b95ecda3f</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.868+01:00</published>
+                <published>2022-11-17T09:39:38.880+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/9ff9d880-6b48-3b3c-982b-bb7b95ecda3f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12926,7 +12926,7 @@ http_interactions:
             <entry>
                 <id>ca198d5b-59da-3103-8f49-8052e45ce3b8</id>
                 <title>VirtualNetwork</title>
-                <published>2022-11-16T11:48:32.869+01:00</published>
+                <published>2022-11-17T09:39:38.881+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -12950,7 +12950,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:18 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:23 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition?group=None
@@ -12975,7 +12975,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-810142332"
+      - "-394391158"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -12990,14 +12990,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>c5f65b8d-6f75-3d4d-a4eb-9d2abc8bde17</id>
-            <updated>2022-11-16T11:48:33.080+01:00</updated>
+            <updated>2022-11-17T09:39:39.091+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>0D237132-32FD-4208-B263-5E273080FCC2</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.850+01:00</published>
+                <published>2022-11-17T09:39:39.260+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/0D237132-32FD-4208-B263-5E273080FCC2?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -13161,7 +13161,7 @@ http_interactions:
             <entry>
                 <id>6B81F3E1-C323-497D-9F91-BA52D09AF91C</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.852+01:00</published>
+                <published>2022-11-17T09:39:39.262+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -13336,7 +13336,7 @@ http_interactions:
             <entry>
                 <id>684292A4-C20D-4AC5-A938-CB409810EF43</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.854+01:00</published>
+                <published>2022-11-17T09:39:39.264+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/684292A4-C20D-4AC5-A938-CB409810EF43?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -13505,7 +13505,7 @@ http_interactions:
             <entry>
                 <id>3200E8AA-2112-4BF9-9686-B3CEE429C2A6</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.856+01:00</published>
+                <published>2022-11-17T09:39:39.266+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/3200E8AA-2112-4BF9-9686-B3CEE429C2A6?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -13672,7 +13672,7 @@ http_interactions:
             <entry>
                 <id>3F3D399B-DFF3-4977-8881-C194AA47CD3A</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.858+01:00</published>
+                <published>2022-11-17T09:39:39.268+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -13839,7 +13839,7 @@ http_interactions:
             <entry>
                 <id>256B63BC-868F-4CB8-AB00-94387264B66A</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.860+01:00</published>
+                <published>2022-11-17T09:39:39.270+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -14008,7 +14008,7 @@ http_interactions:
             <entry>
                 <id>7C5E7B8C-221D-4413-BE31-52002D1C7565</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:33.862+01:00</published>
+                <published>2022-11-17T09:39:39.272+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/7C5E7B8C-221D-4413-BE31-52002D1C7565?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -14162,9 +14162,182 @@ http_interactions:
         </LogicalPartition:LogicalPartition>
                 </content>
             </entry>
+            <entry>
+                <id>1A4585C1-1B74-445F-A6BE-D41BC26DCD04</id>
+                <title>LogicalPartition</title>
+                <published>2022-11-17T09:39:39.274+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04?group=None"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1049782642</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
+                    <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>1A4585C1-1B74-445F-A6BE-D41BC26DCD04</AtomID>
+                    <AtomCreated>1668601899610</AtomCreated>
+                </Atom>
+            </Metadata>
+            <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
+            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04/LogicalPartitionProfile/893100d3-7f79-33d7-99e6-1f51f4861e6d" rel="related"/>
+            <AvailabilityPriority kxe="false" kb="UOD">127</AvailabilityPriority>
+            <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
+            <CurrentProfileSync kb="CUD" kxe="false">On</CurrentProfileSync>
+            <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
+            <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
+            <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
+            <IsRedundantErrorPathReportingEnabled kb="UOD" kxe="false">false</IsRedundantErrorPathReportingEnabled>
+            <IsTimeReferencePartition kb="UOD" kxe="false">false</IsTimeReferencePartition>
+            <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
+            <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
+            <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
+            <LogicalSerialNumber kxe="false" kb="ROR">21FD4AV6</LogicalSerialNumber>
+            <OperatingSystemVersion kb="ROR" kxe="false">Unknown</OperatingSystemVersion>
+            <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
+                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
+                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
+                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
+                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
+            </PartitionCapabilities>
+            <PartitionID kxe="false" kb="COD">6</PartitionID>
+            <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <MaximumVirtualIOSlots kb="CUD" kxe="false">10</MaximumVirtualIOSlots>
+                <ProfileIOSlots kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                </ProfileIOSlots>
+                <CurrentMaximumVirtualIOSlots kxe="false" kb="ROR">10</CurrentMaximumVirtualIOSlots>
+            </PartitionIOConfiguration>
+            <PartitionMemoryConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
+                <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
+                <DesiredEntitledMemory kb="CUD" kxe="false">60</DesiredEntitledMemory>
+                <DesiredHugePageCount kb="CUD" kxe="false">0</DesiredHugePageCount>
+                <DesiredMemory kxe="false" kb="CUD">1024</DesiredMemory>
+                <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
+                <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
+                <ManualEntitledModeEnabled kxe="false" kb="ROR">false</ManualEntitledModeEnabled>
+                <MaximumHugePageCount kxe="false" kb="CUD">0</MaximumHugePageCount>
+                <MaximumMemory kb="CUD" kxe="false">4096</MaximumMemory>
+                <MemoryWeight kxe="false" kb="CUD">128</MemoryWeight>
+                <MinimumHugePageCount kb="CUD" kxe="false">0</MinimumHugePageCount>
+                <MinimumMemory kb="CUD" kxe="false">1024</MinimumMemory>
+                <PrimaryPagingServicePartition kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/0D323064-36E2-455A-AB06-46BD079AD545" rel="related"/>
+                <AutoEntitledMemoryEnabled kb="CUD" kxe="false">true</AutoEntitledMemoryEnabled>
+                <CurrentEntitledMemory kxe="false" kb="ROR">60</CurrentEntitledMemory>
+                <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
+                <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
+                <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
+                <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
+                <CurrentMaximumMemory kxe="false" kb="ROR">4096</CurrentMaximumMemory>
+                <CurrentMemory kb="ROR" kxe="false">1024</CurrentMemory>
+                <CurrentMemoryWeight kb="ROR" kxe="false">128</CurrentMemoryWeight>
+                <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
+                <CurrentMinimumMemory kxe="false" kb="ROR">1024</CurrentMinimumMemory>
+                <CurrentPagingServicePartition kb="ROR" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/0D323064-36E2-455A-AB06-46BD079AD545" rel="related"/>
+                <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
+                <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
+                <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
+                <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
+                <RuntimeEntitledMemory kb="ROR" kxe="false">60</RuntimeEntitledMemory>
+                <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
+                <RuntimeMemory kxe="false" kb="ROR">1024</RuntimeMemory>
+                <RuntimeMemoryWeight kb="ROR" kxe="false">128</RuntimeMemoryWeight>
+                <RuntimeMinimumMemory kxe="false" kb="ROR">1024</RuntimeMinimumMemory>
+                <SharedMemoryEnabled kb="CUD" kxe="false">true</SharedMemoryEnabled>
+            </PartitionMemoryConfiguration>
+            <PartitionName kb="CUR" kxe="false">damien-miq-ams</PartitionName>
+            <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
+                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <DesiredProcessingUnits kxe="false" kb="CUD">0.1</DesiredProcessingUnits>
+                    <DesiredVirtualProcessors kb="CUD" kxe="false">1</DesiredVirtualProcessors>
+                    <MaximumProcessingUnits kxe="false" kb="CUD">0.1</MaximumProcessingUnits>
+                    <MaximumVirtualProcessors kxe="false" kb="CUD">1</MaximumVirtualProcessors>
+                    <MinimumProcessingUnits kb="CUD" kxe="false">0.1</MinimumProcessingUnits>
+                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
+                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
+                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
+                </SharedProcessorConfiguration>
+                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
+                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
+                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
+                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
+                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <AllocatedVirtualProcessors kxe="false" kb="ROR">1</AllocatedVirtualProcessors>
+                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">0.1</CurrentMaximumProcessingUnits>
+                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.1</CurrentMinimumProcessingUnits>
+                    <CurrentProcessingUnits kxe="false" kb="ROR">0.1</CurrentProcessingUnits>
+                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
+                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
+                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
+                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">1</CurrentMaximumVirtualProcessors>
+                    <RuntimeProcessingUnits kxe="false" kb="ROR">0.1</RuntimeProcessingUnits>
+                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
+                </CurrentSharedProcessorConfiguration>
+            </PartitionProcessorConfiguration>
+            <PartitionProfiles kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04/LogicalPartitionProfile/893100d3-7f79-33d7-99e6-1f51f4861e6d" rel="related"/>
+            </PartitionProfiles>
+            <PartitionState kxe="false" kb="ROO">open firmware</PartitionState>
+            <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
+            <PartitionUUID kxe="false" kb="ROO">1A4585C1-1B74-445F-A6BE-D41BC26DCD04</PartitionUUID>
+            <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
+            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/74e47b2e-b370-3cf1-a274-47ee7a6550e7" rel="related"/>
+            <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
+            <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
+            <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37" rel="related"/>
+            <ClientNetworkAdapters kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04/ClientNetworkAdapter/879f6744-e801-34f7-9e94-ad18983f4920" rel="related"/>
+            </ClientNetworkAdapters>
+            <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+            </HostEthernetAdapterLogicalPorts>
+            <MACAddressPrefix kb="ROR" kxe="false">129748379682048</MACAddressPrefix>
+            <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
+            <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
+            <ReferenceCode kb="ROO" kxe="true">AA00E158</ReferenceCode>
+            <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Valid</MigrationStorageViosDataStatus>
+            <MigrationStorageViosDataTimestamp ksv="V1_3_0" kb="ROR" kxe="false">Wed Nov 16 14:15:16 CET 2022</MigrationStorageViosDataTimestamp>
+            <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
+            <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
+            <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
+            <SuspendCapable kxe="false" kb="CUD">true</SuspendCapable>
+            <MigrationDisable ksv="V1_3_0" kxe="false" kb="CUD">false</MigrationDisable>
+            <MigrationState kb="ROR" kxe="false">Not_Migrating</MigrationState>
+            <RemoteRestartState kb="ROR" kxe="false">Invalid</RemoteRestartState>
+            <PrimaryPagingServicePartition ksv="V1_3_0" kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/0D323064-36E2-455A-AB06-46BD079AD545" rel="related"/>
+        </LogicalPartition:LogicalPartition>
+                </content>
+            </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:19 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:23 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition?group=None
@@ -14204,14 +14377,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>9f5da17d-5187-38ef-bf34-e26972841265</id>
-            <updated>2022-11-16T11:48:34.218+01:00</updated>
+            <updated>2022-11-17T09:39:39.977+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>4100CBC1-119B-4674-8178-340879806144</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.984+01:00</published>
+                <published>2022-11-17T09:39:40.111+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/4100CBC1-119B-4674-8178-340879806144?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -14379,7 +14552,7 @@ http_interactions:
             <entry>
                 <id>646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.986+01:00</published>
+                <published>2022-11-17T09:39:40.113+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -14552,7 +14725,7 @@ http_interactions:
             <entry>
                 <id>38643629-EB5A-41F1-82A5-3471433AEFDD</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.989+01:00</published>
+                <published>2022-11-17T09:39:40.115+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/38643629-EB5A-41F1-82A5-3471433AEFDD?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -14719,7 +14892,7 @@ http_interactions:
             <entry>
                 <id>1813FE39-F124-4415-8767-4997C6C24F9C</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.991+01:00</published>
+                <published>2022-11-17T09:39:40.117+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/1813FE39-F124-4415-8767-4997C6C24F9C?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -14887,7 +15060,7 @@ http_interactions:
             <entry>
                 <id>4BB4CBFD-7236-4BE8-934A-1AD6245C6261</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.993+01:00</published>
+                <published>2022-11-17T09:39:40.119+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/4BB4CBFD-7236-4BE8-934A-1AD6245C6261?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -15053,7 +15226,7 @@ http_interactions:
             <entry>
                 <id>40AFE87B-0DAB-4B05-9267-5A18295DF4F0</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.995+01:00</published>
+                <published>2022-11-17T09:39:40.121+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/40AFE87B-0DAB-4B05-9267-5A18295DF4F0?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -15219,7 +15392,7 @@ http_interactions:
             <entry>
                 <id>575E866B-6B4F-4E9D-8B26-F72DE6389703</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:34.997+01:00</published>
+                <published>2022-11-17T09:39:40.123+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/575E866B-6B4F-4E9D-8B26-F72DE6389703?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -15385,7 +15558,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:20 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:24 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition?group=None
@@ -15410,7 +15583,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '1349265088'
+      - '2114833131'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -15425,179 +15598,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>bfe8ba7d-38cf-32a3-8643-fec9952cbc77</id>
-            <updated>2022-11-16T11:48:35.380+01:00</updated>
+            <updated>2022-11-17T09:39:40.571+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
-                <id>4636108C-4424-4490-808A-9C6764F2B874</id>
-                <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.841+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874?group=None"/>
-                <author>
-                    <name>IBM Power Systems Management Console</name>
-                </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-790447182</etag:etag>
-                <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
-                    <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
-            <Metadata>
-                <Atom>
-                    <AtomID>4636108C-4424-4490-808A-9C6764F2B874</AtomID>
-                    <AtomCreated>1667813811279</AtomCreated>
-                </Atom>
-            </Metadata>
-            <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
-            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/LogicalPartitionProfile/c0f16696-86e4-327d-89f7-bcb3e5ac353a" rel="related"/>
-            <AvailabilityPriority kxe="false" kb="UOD">127</AvailabilityPriority>
-            <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
-            <CurrentProfileSync kb="CUD" kxe="false">Disabled</CurrentProfileSync>
-            <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
-            <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
-            <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
-            <IsRedundantErrorPathReportingEnabled kb="UOD" kxe="false">false</IsRedundantErrorPathReportingEnabled>
-            <IsTimeReferencePartition kb="UOD" kxe="false">false</IsTimeReferencePartition>
-            <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
-            <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
-            <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
-            <LogicalSerialNumber kxe="false" kb="ROR">214D29VM</LogicalSerialNumber>
-            <OperatingSystemVersion kb="ROR" kxe="false">Linux/Hardware Management Conso V10R2 1030</OperatingSystemVersion>
-            <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">true</DynamicLogicalPartitionIOCapable>
-                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">true</DynamicLogicalPartitionMemoryCapable>
-                <DynamicLogicalPartitionVIOSCapable ksv="V1_5_0" kxe="false" kb="ROR">false</DynamicLogicalPartitionVIOSCapable>
-                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">true</DynamicLogicalPartitionProcessorCapable>
-                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">true</InternalAndExternalIntrusionDetectionCapable>
-                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">true</ResourceMonitoringControlOperatingSystemShutdownCapable>
-            </PartitionCapabilities>
-            <PartitionID kxe="false" kb="COD">22</PartitionID>
-            <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <MaximumVirtualIOSlots kb="CUD" kxe="false">10</MaximumVirtualIOSlots>
-                <ProfileIOSlots kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                </ProfileIOSlots>
-                <CurrentMaximumVirtualIOSlots kxe="false" kb="ROR">10</CurrentMaximumVirtualIOSlots>
-            </PartitionIOConfiguration>
-            <PartitionMemoryConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
-                <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
-                <DesiredHugePageCount kb="CUD" kxe="false">0</DesiredHugePageCount>
-                <DesiredMemory kxe="false" kb="CUD">16384</DesiredMemory>
-                <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
-                <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
-                <MaximumHugePageCount kxe="false" kb="CUD">0</MaximumHugePageCount>
-                <MaximumMemory kb="CUD" kxe="false">24576</MaximumMemory>
-                <MinimumHugePageCount kb="CUD" kxe="false">0</MinimumHugePageCount>
-                <MinimumMemory kb="CUD" kxe="false">8192</MinimumMemory>
-                <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
-                <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
-                <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
-                <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
-                <CurrentMaximumMemory kxe="false" kb="ROR">24576</CurrentMaximumMemory>
-                <CurrentMemory kb="ROR" kxe="false">16384</CurrentMemory>
-                <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
-                <CurrentMinimumMemory kxe="false" kb="ROR">8192</CurrentMinimumMemory>
-                <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
-                <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
-                <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
-                <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
-                <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
-                <RuntimeMemory kxe="false" kb="ROR">16384</RuntimeMemory>
-                <RuntimeMinimumMemory kxe="false" kb="ROR">8192</RuntimeMinimumMemory>
-                <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
-            </PartitionMemoryConfiguration>
-            <PartitionName kb="CUR" kxe="false">hmcv10</PartitionName>
-            <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
-                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <DesiredProcessingUnits kxe="false" kb="CUD">0.2</DesiredProcessingUnits>
-                    <DesiredVirtualProcessors kb="CUD" kxe="false">4</DesiredVirtualProcessors>
-                    <MaximumProcessingUnits kxe="false" kb="CUD">0.5</MaximumProcessingUnits>
-                    <MaximumVirtualProcessors kxe="false" kb="CUD">4</MaximumVirtualProcessors>
-                    <MinimumProcessingUnits kb="CUD" kxe="false">0.1</MinimumProcessingUnits>
-                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
-                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
-                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
-                </SharedProcessorConfiguration>
-                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
-                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
-                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
-                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
-                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <AllocatedVirtualProcessors kxe="false" kb="ROR">4</AllocatedVirtualProcessors>
-                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">0.5</CurrentMaximumProcessingUnits>
-                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.1</CurrentMinimumProcessingUnits>
-                    <CurrentProcessingUnits kxe="false" kb="ROR">0.2</CurrentProcessingUnits>
-                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
-                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
-                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
-                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">4</CurrentMaximumVirtualProcessors>
-                    <RuntimeProcessingUnits kxe="false" kb="ROR">0.2</RuntimeProcessingUnits>
-                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
-                </CurrentSharedProcessorConfiguration>
-            </PartitionProcessorConfiguration>
-            <PartitionProfiles kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/LogicalPartitionProfile/c0f16696-86e4-327d-89f7-bcb3e5ac353a" rel="related"/>
-            </PartitionProfiles>
-            <PartitionState kxe="false" kb="ROO">running</PartitionState>
-            <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
-            <PartitionUUID kxe="false" kb="ROO">4636108C-4424-4490-808A-9C6764F2B874</PartitionUUID>
-            <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
-            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
-            <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
-            <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">active</ResourceMonitoringControlState>
-            <ResourceMonitoringIPAddress kb="CUD" kxe="false">10.197.64.104</ResourceMonitoringIPAddress>
-            <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
-            <ClientNetworkAdapters kxe="false" kb="CUR">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter/56639748-8ecc-3726-811e-59b4e173e28d" rel="related"/>
-            </ClientNetworkAdapters>
-            <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-            </HostEthernetAdapterLogicalPorts>
-            <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
-            <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
-            <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
-            <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
-            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">No_Data</MigrationStorageViosDataStatus>
-            <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
-            <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
-            <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
-            <SuspendCapable kxe="false" kb="CUD">false</SuspendCapable>
-            <MigrationDisable ksv="V1_3_0" kxe="false" kb="CUD">false</MigrationDisable>
-            <MigrationState kb="ROR" kxe="false">Not_Migrating</MigrationState>
-            <RemoteRestartState kb="ROR" kxe="false">Invalid</RemoteRestartState>
-            <VirtualSCSIClientAdapters kb="CUR" kxe="false">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/VirtualSCSIClientAdapter/b62db2fa-d7e6-37c4-8a0c-acb10d0b24c6" rel="related"/>
-            </VirtualSCSIClientAdapters>
-        </LogicalPartition:LogicalPartition>
-                </content>
-            </entry>
-            <entry>
                 <id>2C36105C-7547-49DC-BEB0-3753552506C5</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.842+01:00</published>
+                <published>2022-11-17T09:39:40.782+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -15758,7 +15766,7 @@ http_interactions:
             <entry>
                 <id>0611F373-2215-4103-9D05-8E162E67ADBD</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.844+01:00</published>
+                <published>2022-11-17T09:39:40.784+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/0611F373-2215-4103-9D05-8E162E67ADBD?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -15920,7 +15928,7 @@ http_interactions:
             <entry>
                 <id>51B91FAB-1C58-4B9C-B239-878C01D5089C</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.846+01:00</published>
+                <published>2022-11-17T09:39:40.786+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -16084,7 +16092,7 @@ http_interactions:
             <entry>
                 <id>7F840DA7-9563-40B0-B913-DDDF3368BCEE</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.848+01:00</published>
+                <published>2022-11-17T09:39:40.788+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -16248,7 +16256,7 @@ http_interactions:
             <entry>
                 <id>29368E9C-E187-435C-8BA7-43770478B9BC</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.850+01:00</published>
+                <published>2022-11-17T09:39:40.790+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -16412,7 +16420,7 @@ http_interactions:
             <entry>
                 <id>264C3673-F340-4D79-9AC7-5FD6E3293C44</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.852+01:00</published>
+                <published>2022-11-17T09:39:40.792+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/264C3673-F340-4D79-9AC7-5FD6E3293C44?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -16577,7 +16585,7 @@ http_interactions:
             <entry>
                 <id>242BA00C-AF20-49E3-AF71-704922DDD4DA</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.854+01:00</published>
+                <published>2022-11-17T09:39:40.794+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/242BA00C-AF20-49E3-AF71-704922DDD4DA?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -16742,7 +16750,7 @@ http_interactions:
             <entry>
                 <id>2B3795A9-AD12-4887-95AE-691E80611E4F</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.856+01:00</published>
+                <published>2022-11-17T09:39:40.796+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/2B3795A9-AD12-4887-95AE-691E80611E4F?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -16907,7 +16915,7 @@ http_interactions:
             <entry>
                 <id>3BD7BF62-1ED0-4AF1-A605-D8E6A9FACDD9</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.858+01:00</published>
+                <published>2022-11-17T09:39:40.798+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/3BD7BF62-1ED0-4AF1-A605-D8E6A9FACDD9?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -17072,7 +17080,7 @@ http_interactions:
             <entry>
                 <id>2D5E4DBF-5294-493F-9F0C-A1D4776F10D2</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.860+01:00</published>
+                <published>2022-11-17T09:39:40.800+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/2D5E4DBF-5294-493F-9F0C-A1D4776F10D2?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -17236,7 +17244,7 @@ http_interactions:
             <entry>
                 <id>18CF2B4F-BE3D-4CF4-A28C-1483D89DCB9F</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.862+01:00</published>
+                <published>2022-11-17T09:39:40.802+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/18CF2B4F-BE3D-4CF4-A28C-1483D89DCB9F?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -17399,175 +17407,9 @@ http_interactions:
                 </content>
             </entry>
             <entry>
-                <id>18278B69-2634-4697-AAD0-CC6BCA022507</id>
-                <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.864+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507?group=None"/>
-                <author>
-                    <name>IBM Power Systems Management Console</name>
-                </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-140896190</etag:etag>
-                <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
-                    <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
-            <Metadata>
-                <Atom>
-                    <AtomID>18278B69-2634-4697-AAD0-CC6BCA022507</AtomID>
-                    <AtomCreated>1667813811306</AtomCreated>
-                </Atom>
-            </Metadata>
-            <AllowPerformanceDataCollection kxe="false" kb="CUD">true</AllowPerformanceDataCollection>
-            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/LogicalPartitionProfile/a571c7d5-f270-3ab4-91a8-842157965a21" rel="related"/>
-            <AvailabilityPriority kxe="false" kb="UOD">127</AvailabilityPriority>
-            <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
-            <CurrentProfileSync kb="CUD" kxe="false">Disabled</CurrentProfileSync>
-            <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
-            <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
-            <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
-            <IsRedundantErrorPathReportingEnabled kb="UOD" kxe="false">false</IsRedundantErrorPathReportingEnabled>
-            <IsTimeReferencePartition kb="UOD" kxe="false">false</IsTimeReferencePartition>
-            <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
-            <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
-            <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
-            <LogicalSerialNumber kxe="false" kb="ROR">214D29VA</LogicalSerialNumber>
-            <OperatingSystemVersion kb="ROR" kxe="false">Unknown</OperatingSystemVersion>
-            <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
-                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
-                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
-                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
-                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
-            </PartitionCapabilities>
-            <PartitionID kxe="false" kb="COD">10</PartitionID>
-            <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <MaximumVirtualIOSlots kb="CUD" kxe="false">10</MaximumVirtualIOSlots>
-                <ProfileIOSlots kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                </ProfileIOSlots>
-                <CurrentMaximumVirtualIOSlots kxe="false" kb="ROR">10</CurrentMaximumVirtualIOSlots>
-            </PartitionIOConfiguration>
-            <PartitionMemoryConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
-                <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
-                <DesiredHugePageCount kb="CUD" kxe="false">0</DesiredHugePageCount>
-                <DesiredMemory kxe="false" kb="CUD">8192</DesiredMemory>
-                <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
-                <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
-                <MaximumHugePageCount kxe="false" kb="CUD">0</MaximumHugePageCount>
-                <MaximumMemory kb="CUD" kxe="false">16384</MaximumMemory>
-                <MinimumHugePageCount kb="CUD" kxe="false">0</MinimumHugePageCount>
-                <MinimumMemory kb="CUD" kxe="false">2048</MinimumMemory>
-                <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
-                <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
-                <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
-                <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
-                <CurrentMaximumMemory kxe="false" kb="ROR">16384</CurrentMaximumMemory>
-                <CurrentMemory kb="ROR" kxe="false">8192</CurrentMemory>
-                <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
-                <CurrentMinimumMemory kxe="false" kb="ROR">2048</CurrentMinimumMemory>
-                <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
-                <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
-                <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
-                <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
-                <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
-                <RuntimeMemory kxe="false" kb="ROR">8192</RuntimeMemory>
-                <RuntimeMinimumMemory kxe="false" kb="ROR">2048</RuntimeMinimumMemory>
-                <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
-            </PartitionMemoryConfiguration>
-            <PartitionName kb="CUR" kxe="false">ocp-infra</PartitionName>
-            <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
-                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <DesiredProcessingUnits kxe="false" kb="CUD">0.2</DesiredProcessingUnits>
-                    <DesiredVirtualProcessors kb="CUD" kxe="false">1</DesiredVirtualProcessors>
-                    <MaximumProcessingUnits kxe="false" kb="CUD">1</MaximumProcessingUnits>
-                    <MaximumVirtualProcessors kxe="false" kb="CUD">4</MaximumVirtualProcessors>
-                    <MinimumProcessingUnits kb="CUD" kxe="false">0.1</MinimumProcessingUnits>
-                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
-                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
-                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
-                </SharedProcessorConfiguration>
-                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
-                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
-                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
-                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
-                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <AllocatedVirtualProcessors kxe="false" kb="ROR">1</AllocatedVirtualProcessors>
-                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">1</CurrentMaximumProcessingUnits>
-                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.1</CurrentMinimumProcessingUnits>
-                    <CurrentProcessingUnits kxe="false" kb="ROR">0.2</CurrentProcessingUnits>
-                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
-                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
-                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
-                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">4</CurrentMaximumVirtualProcessors>
-                    <RuntimeProcessingUnits kxe="false" kb="ROR">0.2</RuntimeProcessingUnits>
-                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
-                </CurrentSharedProcessorConfiguration>
-            </PartitionProcessorConfiguration>
-            <PartitionProfiles kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/LogicalPartitionProfile/a571c7d5-f270-3ab4-91a8-842157965a21" rel="related"/>
-            </PartitionProfiles>
-            <PartitionState kxe="false" kb="ROO">running</PartitionState>
-            <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
-            <PartitionUUID kxe="false" kb="ROO">18278B69-2634-4697-AAD0-CC6BCA022507</PartitionUUID>
-            <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
-            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
-            <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
-            <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
-            <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
-            <ClientNetworkAdapters kxe="false" kb="CUR">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter/25c1ba09-7f19-3865-a83d-ec672d0237aa" rel="related"/>
-            </ClientNetworkAdapters>
-            <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-            </HostEthernetAdapterLogicalPorts>
-            <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
-            <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
-            <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
-            <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
-            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">No_Data</MigrationStorageViosDataStatus>
-            <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
-            <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
-            <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
-            <SuspendCapable kxe="false" kb="CUD">false</SuspendCapable>
-            <MigrationDisable ksv="V1_3_0" kxe="false" kb="CUD">false</MigrationDisable>
-            <MigrationState kb="ROR" kxe="false">Not_Migrating</MigrationState>
-            <RemoteRestartState kb="ROR" kxe="false">Invalid</RemoteRestartState>
-            <VirtualFibreChannelClientAdapters kb="CUR" kxe="false">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/VirtualFibreChannelClientAdapter/7c2af7bd-9dbb-31f0-b94c-c8a1b08bc3e6" rel="related"/>
-            </VirtualFibreChannelClientAdapters>
-            <VirtualSCSIClientAdapters kb="CUR" kxe="false">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/VirtualSCSIClientAdapter/ceaa61e2-7c52-35ba-932e-8852cd021ba0" rel="related"/>
-            </VirtualSCSIClientAdapters>
-        </LogicalPartition:LogicalPartition>
-                </content>
-            </entry>
-            <entry>
                 <id>1A5797C3-595D-4B52-A217-1C6A75B4F4C0</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.866+01:00</published>
+                <published>2022-11-17T09:39:40.804+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -17735,7 +17577,7 @@ http_interactions:
             <entry>
                 <id>6F67D796-80BA-457F-9E81-2B307A484294</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.868+01:00</published>
+                <published>2022-11-17T09:39:40.806+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/6F67D796-80BA-457F-9E81-2B307A484294?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -17896,7 +17738,7 @@ http_interactions:
             <entry>
                 <id>7D1DAADD-36EF-4D78-95EE-1E9B8C656DA1</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.870+01:00</published>
+                <published>2022-11-17T09:39:40.808+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/7D1DAADD-36EF-4D78-95EE-1E9B8C656DA1?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18057,7 +17899,7 @@ http_interactions:
             <entry>
                 <id>40381833-1012-44B9-8455-E2D6B9BD00EE</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.872+01:00</published>
+                <published>2022-11-17T09:39:40.810+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/40381833-1012-44B9-8455-E2D6B9BD00EE?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18221,7 +18063,7 @@ http_interactions:
             <entry>
                 <id>654DC1E7-ECD3-4424-88CF-3E23E1004257</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.874+01:00</published>
+                <published>2022-11-17T09:39:40.812+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18388,27 +18230,27 @@ http_interactions:
                 </content>
             </entry>
             <entry>
-                <id>4B2A17C0-0FB1-4B3E-8354-94A6D25380D1</id>
+                <id>4636108C-4424-4490-808A-9C6764F2B874</id>
                 <title>LogicalPartition</title>
-                <published>2022-11-16T11:48:37.876+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/4B2A17C0-0FB1-4B3E-8354-94A6D25380D1?group=None"/>
+                <published>2022-11-17T09:39:40.814+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874?group=None"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1415149361</etag:etag>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-790447182</etag:etag>
                 <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                     <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
-                    <AtomID>4B2A17C0-0FB1-4B3E-8354-94A6D25380D1</AtomID>
-                    <AtomCreated>1668587952325</AtomCreated>
+                    <AtomID>4636108C-4424-4490-808A-9C6764F2B874</AtomID>
+                    <AtomCreated>1667813811279</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
-            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4B2A17C0-0FB1-4B3E-8354-94A6D25380D1/LogicalPartitionProfile/8d1dcb6f-b8e6-3fcc-a75e-817c941255a2" rel="related"/>
+            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/LogicalPartitionProfile/c0f16696-86e4-327d-89f7-bcb3e5ac353a" rel="related"/>
             <AvailabilityPriority kxe="false" kb="UOD">127</AvailabilityPriority>
             <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
-            <CurrentProfileSync kb="CUD" kxe="false">On</CurrentProfileSync>
+            <CurrentProfileSync kb="CUD" kxe="false">Disabled</CurrentProfileSync>
             <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
             <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
             <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
@@ -18417,19 +18259,20 @@ http_interactions:
             <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
             <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
             <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
-            <LogicalSerialNumber kxe="false" kb="ROR">214D29VN</LogicalSerialNumber>
-            <OperatingSystemVersion kb="ROR" kxe="false">Unknown</OperatingSystemVersion>
+            <LogicalSerialNumber kxe="false" kb="ROR">214D29VM</LogicalSerialNumber>
+            <OperatingSystemVersion kb="ROR" kxe="false">Linux/Hardware Management Conso V10R2 1030</OperatingSystemVersion>
             <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
                 <Metadata>
                     <Atom/>
                 </Metadata>
-                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
-                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
-                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
-                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
-                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
+                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">true</DynamicLogicalPartitionIOCapable>
+                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">true</DynamicLogicalPartitionMemoryCapable>
+                <DynamicLogicalPartitionVIOSCapable ksv="V1_5_0" kxe="false" kb="ROR">false</DynamicLogicalPartitionVIOSCapable>
+                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">true</DynamicLogicalPartitionProcessorCapable>
+                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">true</InternalAndExternalIntrusionDetectionCapable>
+                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">true</ResourceMonitoringControlOperatingSystemShutdownCapable>
             </PartitionCapabilities>
-            <PartitionID kxe="false" kb="COD">23</PartitionID>
+            <PartitionID kxe="false" kb="COD">22</PartitionID>
             <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
                 <Metadata>
                     <Atom/>
@@ -18449,69 +18292,85 @@ http_interactions:
                 <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
                 <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
                 <DesiredHugePageCount kb="CUD" kxe="false">0</DesiredHugePageCount>
-                <DesiredMemory kxe="false" kb="CUD">1024</DesiredMemory>
+                <DesiredMemory kxe="false" kb="CUD">16384</DesiredMemory>
                 <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
                 <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
                 <MaximumHugePageCount kxe="false" kb="CUD">0</MaximumHugePageCount>
-                <MaximumMemory kb="CUD" kxe="false">4096</MaximumMemory>
+                <MaximumMemory kb="CUD" kxe="false">24576</MaximumMemory>
                 <MinimumHugePageCount kb="CUD" kxe="false">0</MinimumHugePageCount>
-                <MinimumMemory kb="CUD" kxe="false">1024</MinimumMemory>
+                <MinimumMemory kb="CUD" kxe="false">8192</MinimumMemory>
                 <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
                 <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
                 <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
                 <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
-                <CurrentMaximumMemory kxe="false" kb="ROR">4096</CurrentMaximumMemory>
-                <CurrentMemory kb="ROR" kxe="false">1024</CurrentMemory>
+                <CurrentMaximumMemory kxe="false" kb="ROR">24576</CurrentMaximumMemory>
+                <CurrentMemory kb="ROR" kxe="false">16384</CurrentMemory>
                 <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
-                <CurrentMinimumMemory kxe="false" kb="ROR">1024</CurrentMinimumMemory>
+                <CurrentMinimumMemory kxe="false" kb="ROR">8192</CurrentMinimumMemory>
                 <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
                 <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
                 <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
                 <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
                 <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
-                <RuntimeMemory kxe="false" kb="ROR">256</RuntimeMemory>
-                <RuntimeMinimumMemory kxe="false" kb="ROR">1024</RuntimeMinimumMemory>
+                <RuntimeMemory kxe="false" kb="ROR">16384</RuntimeMemory>
+                <RuntimeMinimumMemory kxe="false" kb="ROR">8192</RuntimeMinimumMemory>
                 <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
             </PartitionMemoryConfiguration>
-            <PartitionName kb="CUR" kxe="false">damien-miq-test-ded</PartitionName>
+            <PartitionName kb="CUR" kxe="false">hmcv10</PartitionName>
             <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
                 <Metadata>
                     <Atom/>
                 </Metadata>
-                <DedicatedProcessorConfiguration kxe="false" kb="CUD" schemaVersion="V1_5_0">
+                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
+                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
                     <Metadata>
                         <Atom/>
                     </Metadata>
-                    <DesiredProcessors kb="CUD" kxe="false">1</DesiredProcessors>
-                    <MaximumProcessors kb="CUD" kxe="false">2</MaximumProcessors>
-                    <MinimumProcessors kxe="false" kb="CUD">1</MinimumProcessors>
-                </DedicatedProcessorConfiguration>
-                <HasDedicatedProcessors kxe="false" kb="CUD">true</HasDedicatedProcessors>
-                <SharingMode kxe="false" kb="CUD">keep idle procs</SharingMode>
-                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">true</CurrentHasDedicatedProcessors>
-                <CurrentSharingMode kb="ROR" kxe="false">keep idle procs</CurrentSharingMode>
-                <CurrentDedicatedProcessorConfiguration kxe="false" kb="ROR" schemaVersion="V1_5_0">
+                    <DesiredProcessingUnits kxe="false" kb="CUD">0.2</DesiredProcessingUnits>
+                    <DesiredVirtualProcessors kb="CUD" kxe="false">4</DesiredVirtualProcessors>
+                    <MaximumProcessingUnits kxe="false" kb="CUD">0.5</MaximumProcessingUnits>
+                    <MaximumVirtualProcessors kxe="false" kb="CUD">4</MaximumVirtualProcessors>
+                    <MinimumProcessingUnits kb="CUD" kxe="false">0.1</MinimumProcessingUnits>
+                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
+                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
+                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
+                </SharedProcessorConfiguration>
+                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
+                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
+                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
+                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
+                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
                     <Metadata>
                         <Atom/>
                     </Metadata>
-                    <CurrentMaximumProcessors kxe="false" kb="ROR">2</CurrentMaximumProcessors>
-                    <CurrentMinimumProcessors kb="ROR" kxe="false">1</CurrentMinimumProcessors>
-                    <CurrentProcessors kb="ROR" kxe="false">1</CurrentProcessors>
-                    <RunProcessors kb="ROR" kxe="false">0</RunProcessors>
-                </CurrentDedicatedProcessorConfiguration>
-                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">true</RuntimeHasDedicatedProcessors>
+                    <AllocatedVirtualProcessors kxe="false" kb="ROR">4</AllocatedVirtualProcessors>
+                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">0.5</CurrentMaximumProcessingUnits>
+                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.1</CurrentMinimumProcessingUnits>
+                    <CurrentProcessingUnits kxe="false" kb="ROR">0.2</CurrentProcessingUnits>
+                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
+                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
+                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
+                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">4</CurrentMaximumVirtualProcessors>
+                    <RuntimeProcessingUnits kxe="false" kb="ROR">0.2</RuntimeProcessingUnits>
+                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
+                </CurrentSharedProcessorConfiguration>
             </PartitionProcessorConfiguration>
             <PartitionProfiles kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4B2A17C0-0FB1-4B3E-8354-94A6D25380D1/LogicalPartitionProfile/8d1dcb6f-b8e6-3fcc-a75e-817c941255a2" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/LogicalPartitionProfile/c0f16696-86e4-327d-89f7-bcb3e5ac353a" rel="related"/>
             </PartitionProfiles>
-            <PartitionState kxe="false" kb="ROO">not activated</PartitionState>
+            <PartitionState kxe="false" kb="ROO">running</PartitionState>
             <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
-            <PartitionUUID kxe="false" kb="ROO">4B2A17C0-0FB1-4B3E-8354-94A6D25380D1</PartitionUUID>
+            <PartitionUUID kxe="false" kb="ROO">4636108C-4424-4490-808A-9C6764F2B874</PartitionUUID>
             <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
+            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
             <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
             <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">active</ResourceMonitoringControlState>
+            <ResourceMonitoringIPAddress kb="CUD" kxe="false">10.197.64.104</ResourceMonitoringIPAddress>
             <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
+            <ClientNetworkAdapters kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter/56639748-8ecc-3726-811e-59b4e173e28d" rel="related"/>
+            </ClientNetworkAdapters>
             <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
                 <Metadata>
                     <Atom/>
@@ -18519,23 +18378,191 @@ http_interactions:
             </HostEthernetAdapterLogicalPorts>
             <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
-            <ReferenceCode kb="ROO" kxe="true">00000000</ReferenceCode>
+            <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
-            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Valid</MigrationStorageViosDataStatus>
-            <MigrationStorageViosDataTimestamp ksv="V1_3_0" kb="ROR" kxe="false">Wed Nov 16 11:17:25 CET 2022</MigrationStorageViosDataTimestamp>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">No_Data</MigrationStorageViosDataStatus>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
             <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
-            <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">true</HasDedicatedProcessorsForMigration>
+            <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
             <SuspendCapable kxe="false" kb="CUD">false</SuspendCapable>
             <MigrationDisable ksv="V1_3_0" kxe="false" kb="CUD">false</MigrationDisable>
             <MigrationState kb="ROR" kxe="false">Not_Migrating</MigrationState>
             <RemoteRestartState kb="ROR" kxe="false">Invalid</RemoteRestartState>
+            <VirtualSCSIClientAdapters kb="CUR" kxe="false">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/VirtualSCSIClientAdapter/b62db2fa-d7e6-37c4-8a0c-acb10d0b24c6" rel="related"/>
+            </VirtualSCSIClientAdapters>
+        </LogicalPartition:LogicalPartition>
+                </content>
+            </entry>
+            <entry>
+                <id>18278B69-2634-4697-AAD0-CC6BCA022507</id>
+                <title>LogicalPartition</title>
+                <published>2022-11-17T09:39:40.816+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507?group=None"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-140896190</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
+                    <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>18278B69-2634-4697-AAD0-CC6BCA022507</AtomID>
+                    <AtomCreated>1667813811306</AtomCreated>
+                </Atom>
+            </Metadata>
+            <AllowPerformanceDataCollection kxe="false" kb="CUD">true</AllowPerformanceDataCollection>
+            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/LogicalPartitionProfile/a571c7d5-f270-3ab4-91a8-842157965a21" rel="related"/>
+            <AvailabilityPriority kxe="false" kb="UOD">127</AvailabilityPriority>
+            <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
+            <CurrentProfileSync kb="CUD" kxe="false">Disabled</CurrentProfileSync>
+            <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
+            <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
+            <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
+            <IsRedundantErrorPathReportingEnabled kb="UOD" kxe="false">false</IsRedundantErrorPathReportingEnabled>
+            <IsTimeReferencePartition kb="UOD" kxe="false">false</IsTimeReferencePartition>
+            <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
+            <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
+            <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
+            <LogicalSerialNumber kxe="false" kb="ROR">214D29VA</LogicalSerialNumber>
+            <OperatingSystemVersion kb="ROR" kxe="false">Unknown</OperatingSystemVersion>
+            <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
+                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
+                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
+                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
+                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
+            </PartitionCapabilities>
+            <PartitionID kxe="false" kb="COD">10</PartitionID>
+            <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <MaximumVirtualIOSlots kb="CUD" kxe="false">10</MaximumVirtualIOSlots>
+                <ProfileIOSlots kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                </ProfileIOSlots>
+                <CurrentMaximumVirtualIOSlots kxe="false" kb="ROR">10</CurrentMaximumVirtualIOSlots>
+            </PartitionIOConfiguration>
+            <PartitionMemoryConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
+                <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
+                <DesiredHugePageCount kb="CUD" kxe="false">0</DesiredHugePageCount>
+                <DesiredMemory kxe="false" kb="CUD">8192</DesiredMemory>
+                <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
+                <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
+                <MaximumHugePageCount kxe="false" kb="CUD">0</MaximumHugePageCount>
+                <MaximumMemory kb="CUD" kxe="false">16384</MaximumMemory>
+                <MinimumHugePageCount kb="CUD" kxe="false">0</MinimumHugePageCount>
+                <MinimumMemory kb="CUD" kxe="false">2048</MinimumMemory>
+                <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
+                <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
+                <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
+                <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
+                <CurrentMaximumMemory kxe="false" kb="ROR">16384</CurrentMaximumMemory>
+                <CurrentMemory kb="ROR" kxe="false">8192</CurrentMemory>
+                <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
+                <CurrentMinimumMemory kxe="false" kb="ROR">2048</CurrentMinimumMemory>
+                <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
+                <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
+                <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
+                <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
+                <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
+                <RuntimeMemory kxe="false" kb="ROR">8192</RuntimeMemory>
+                <RuntimeMinimumMemory kxe="false" kb="ROR">2048</RuntimeMinimumMemory>
+                <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
+            </PartitionMemoryConfiguration>
+            <PartitionName kb="CUR" kxe="false">ocp-infra</PartitionName>
+            <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
+                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <DesiredProcessingUnits kxe="false" kb="CUD">0.2</DesiredProcessingUnits>
+                    <DesiredVirtualProcessors kb="CUD" kxe="false">1</DesiredVirtualProcessors>
+                    <MaximumProcessingUnits kxe="false" kb="CUD">1</MaximumProcessingUnits>
+                    <MaximumVirtualProcessors kxe="false" kb="CUD">4</MaximumVirtualProcessors>
+                    <MinimumProcessingUnits kb="CUD" kxe="false">0.1</MinimumProcessingUnits>
+                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
+                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
+                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
+                </SharedProcessorConfiguration>
+                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
+                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
+                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
+                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
+                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <AllocatedVirtualProcessors kxe="false" kb="ROR">1</AllocatedVirtualProcessors>
+                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">1</CurrentMaximumProcessingUnits>
+                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.1</CurrentMinimumProcessingUnits>
+                    <CurrentProcessingUnits kxe="false" kb="ROR">0.2</CurrentProcessingUnits>
+                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
+                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
+                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
+                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">4</CurrentMaximumVirtualProcessors>
+                    <RuntimeProcessingUnits kxe="false" kb="ROR">0.2</RuntimeProcessingUnits>
+                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
+                </CurrentSharedProcessorConfiguration>
+            </PartitionProcessorConfiguration>
+            <PartitionProfiles kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/LogicalPartitionProfile/a571c7d5-f270-3ab4-91a8-842157965a21" rel="related"/>
+            </PartitionProfiles>
+            <PartitionState kxe="false" kb="ROO">running</PartitionState>
+            <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
+            <PartitionUUID kxe="false" kb="ROO">18278B69-2634-4697-AAD0-CC6BCA022507</PartitionUUID>
+            <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
+            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
+            <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
+            <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
+            <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
+            <ClientNetworkAdapters kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter/25c1ba09-7f19-3865-a83d-ec672d0237aa" rel="related"/>
+            </ClientNetworkAdapters>
+            <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+            </HostEthernetAdapterLogicalPorts>
+            <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
+            <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
+            <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
+            <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">No_Data</MigrationStorageViosDataStatus>
+            <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
+            <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
+            <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
+            <SuspendCapable kxe="false" kb="CUD">false</SuspendCapable>
+            <MigrationDisable ksv="V1_3_0" kxe="false" kb="CUD">false</MigrationDisable>
+            <MigrationState kb="ROR" kxe="false">Not_Migrating</MigrationState>
+            <RemoteRestartState kb="ROR" kxe="false">Invalid</RemoteRestartState>
+            <VirtualFibreChannelClientAdapters kb="CUR" kxe="false">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/VirtualFibreChannelClientAdapter/7c2af7bd-9dbb-31f0-b94c-c8a1b08bc3e6" rel="related"/>
+            </VirtualFibreChannelClientAdapters>
+            <VirtualSCSIClientAdapters kb="CUR" kxe="false">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/VirtualSCSIClientAdapter/ceaa61e2-7c52-35ba-932e-8852cd021ba0" rel="related"/>
+            </VirtualSCSIClientAdapters>
         </LogicalPartition:LogicalPartition>
                 </content>
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:23 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:25 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/0D237132-32FD-4208-B263-5E273080FCC2/ClientNetworkAdapter
@@ -18575,14 +18602,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>49a0ad07-80fe-35fe-b44a-ab4daa2473b5</id>
-            <updated>2022-11-16T11:48:38.798+01:00</updated>
+            <updated>2022-11-17T09:39:41.655+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/0D237132-32FD-4208-B263-5E273080FCC2/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>dfdea729-7b99-3410-8a86-5e260d91f8c0</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:38.818+01:00</published>
+                <published>2022-11-17T09:39:41.675+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/0D237132-32FD-4208-B263-5E273080FCC2/ClientNetworkAdapter/dfdea729-7b99-3410-8a86-5e260d91f8c0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18620,7 +18647,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:25 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/ClientNetworkAdapter
@@ -18660,14 +18687,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>9124e4bf-0750-353c-9337-5c545c3ddad0</id>
-            <updated>2022-11-16T11:48:38.865+01:00</updated>
+            <updated>2022-11-17T09:39:41.725+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>c8501979-2a0a-33e9-afd7-e6c59086d962</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:38.886+01:00</published>
+                <published>2022-11-17T09:39:41.746+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/ClientNetworkAdapter/c8501979-2a0a-33e9-afd7-e6c59086d962"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18705,7 +18732,7 @@ http_interactions:
             <entry>
                 <id>67ba181a-632e-3e87-8f4c-6a753bf74334</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:38.886+01:00</published>
+                <published>2022-11-17T09:39:41.747+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/ClientNetworkAdapter/67ba181a-632e-3e87-8f4c-6a753bf74334"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18742,7 +18769,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/684292A4-C20D-4AC5-A938-CB409810EF43/ClientNetworkAdapter
@@ -18782,14 +18809,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>f14adb8b-9ef3-3b00-aba9-c6c3f047824a</id>
-            <updated>2022-11-16T11:48:38.940+01:00</updated>
+            <updated>2022-11-17T09:39:41.802+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/684292A4-C20D-4AC5-A938-CB409810EF43/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>33bb5142-101a-3bc2-b424-3671358efe26</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:38.961+01:00</published>
+                <published>2022-11-17T09:39:41.823+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/684292A4-C20D-4AC5-A938-CB409810EF43/ClientNetworkAdapter/33bb5142-101a-3bc2-b424-3671358efe26"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18827,7 +18854,7 @@ http_interactions:
             <entry>
                 <id>b8d8238e-33d9-3c82-8fb2-63eaf666f426</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:38.962+01:00</published>
+                <published>2022-11-17T09:39:41.823+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/684292A4-C20D-4AC5-A938-CB409810EF43/ClientNetworkAdapter/b8d8238e-33d9-3c82-8fb2-63eaf666f426"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18864,7 +18891,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3200E8AA-2112-4BF9-9686-B3CEE429C2A6/ClientNetworkAdapter
@@ -18904,14 +18931,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>4b15df02-3a97-3950-9a72-a21b84b8179f</id>
-            <updated>2022-11-16T11:48:39.015+01:00</updated>
+            <updated>2022-11-17T09:39:41.880+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3200E8AA-2112-4BF9-9686-B3CEE429C2A6/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>f82b1c4c-ad33-3111-a2e7-a7d281d45ab1</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.036+01:00</published>
+                <published>2022-11-17T09:39:41.900+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3200E8AA-2112-4BF9-9686-B3CEE429C2A6/ClientNetworkAdapter/f82b1c4c-ad33-3111-a2e7-a7d281d45ab1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18949,7 +18976,7 @@ http_interactions:
             <entry>
                 <id>ae9fdb79-b0fb-3355-a8a6-87054a085f0a</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.037+01:00</published>
+                <published>2022-11-17T09:39:41.901+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3200E8AA-2112-4BF9-9686-B3CEE429C2A6/ClientNetworkAdapter/ae9fdb79-b0fb-3355-a8a6-87054a085f0a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -18986,7 +19013,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A/ClientNetworkAdapter
@@ -19026,14 +19053,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>4a91044c-d78a-3c00-80a5-e46388eaef1e</id>
-            <updated>2022-11-16T11:48:39.091+01:00</updated>
+            <updated>2022-11-17T09:39:41.956+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>b146bb7b-5c7c-3426-b97d-72d302859d7d</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.113+01:00</published>
+                <published>2022-11-17T09:39:41.977+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A/ClientNetworkAdapter/b146bb7b-5c7c-3426-b97d-72d302859d7d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19071,7 +19098,7 @@ http_interactions:
             <entry>
                 <id>6438b6cd-47fa-31c3-93f3-c74b31924fba</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.114+01:00</published>
+                <published>2022-11-17T09:39:41.978+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A/ClientNetworkAdapter/6438b6cd-47fa-31c3-93f3-c74b31924fba"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19108,7 +19135,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A/ClientNetworkAdapter
@@ -19148,14 +19175,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>21da4170-d7be-3710-b1bc-54422f406e67</id>
-            <updated>2022-11-16T11:48:39.167+01:00</updated>
+            <updated>2022-11-17T09:39:42.034+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>9c9f9c32-6b6a-33b4-83bd-2aceb87ffcca</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.188+01:00</published>
+                <published>2022-11-17T09:39:42.054+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A/ClientNetworkAdapter/9c9f9c32-6b6a-33b4-83bd-2aceb87ffcca"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19192,7 +19219,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7C5E7B8C-221D-4413-BE31-52002D1C7565/ClientNetworkAdapter
@@ -19232,14 +19259,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>9d3a92c9-10ee-33b6-95b0-16891f3d3c89</id>
-            <updated>2022-11-16T11:48:39.246+01:00</updated>
+            <updated>2022-11-17T09:39:42.102+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7C5E7B8C-221D-4413-BE31-52002D1C7565/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>4ae2737f-ee92-39bf-a1cf-ca6090059ca3</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.266+01:00</published>
+                <published>2022-11-17T09:39:42.123+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7C5E7B8C-221D-4413-BE31-52002D1C7565/ClientNetworkAdapter/4ae2737f-ee92-39bf-a1cf-ca6090059ca3"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19276,7 +19303,91 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04/ClientNetworkAdapter
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - '1337405915'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '3286'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>e00a559e-6958-3d4e-a790-9a733336e885</id>
+            <updated>2022-11-17T09:39:42.172+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04/ClientNetworkAdapter"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>879f6744-e801-34f7-9e94-ad18983f4920</id>
+                <title>ClientNetworkAdapter</title>
+                <published>2022-11-17T09:39:42.210+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04/ClientNetworkAdapter/879f6744-e801-34f7-9e94-ad18983f4920"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1337405884</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
+                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>879f6744-e801-34f7-9e94-ad18983f4920</AtomID>
+                    <AtomCreated>1668602858936</AtomCreated>
+                </Atom>
+            </Metadata>
+            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8284.22A.21FD4AV-V6-C2</DynamicReconfigurationConnectorName>
+            <LocationCode kxe="false" kb="ROR">U8284.22A.21FD4AV-V6-C2</LocationCode>
+            <LocalPartitionID kxe="false" kb="CUR">6</LocalPartitionID>
+            <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
+            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
+            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
+            <MACAddress kxe="false" kb="CUR">76016614C502</MACAddress>
+            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
+            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">false</QualityOfServicePriorityEnabled>
+            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
+            <AssociatedVirtualSwitch kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualSwitch/0f7592e9-5f09-3d6b-8a2e-57ea3b7babc6" rel="related"/>
+            </AssociatedVirtualSwitch>
+            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
+            <VirtualNetworks kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualNetwork/d5d8a713-5ece-332a-8640-6e68fa219fc1" rel="related"/>
+            </VirtualNetworks>
+        </ClientNetworkAdapter:ClientNetworkAdapter>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4100CBC1-119B-4674-8178-340879806144/ClientNetworkAdapter
@@ -19316,14 +19427,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>9590f06d-0620-3bf0-aaeb-965dba4767e9</id>
-            <updated>2022-11-16T11:48:39.310+01:00</updated>
+            <updated>2022-11-17T09:39:42.259+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4100CBC1-119B-4674-8178-340879806144/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>094e29d1-580d-3323-b44d-d148e13ebc05</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.331+01:00</published>
+                <published>2022-11-17T09:39:42.280+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4100CBC1-119B-4674-8178-340879806144/ClientNetworkAdapter/094e29d1-580d-3323-b44d-d148e13ebc05"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19360,7 +19471,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/ClientNetworkAdapter
@@ -19400,14 +19511,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>e3f2bc22-7672-3b34-9540-db3e249c0e02</id>
-            <updated>2022-11-16T11:48:39.376+01:00</updated>
+            <updated>2022-11-17T09:39:42.328+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>343b5c2d-f80e-3749-9f28-47881f8fb814</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.397+01:00</published>
+                <published>2022-11-17T09:39:42.349+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/ClientNetworkAdapter/343b5c2d-f80e-3749-9f28-47881f8fb814"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19444,7 +19555,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/38643629-EB5A-41F1-82A5-3471433AEFDD/ClientNetworkAdapter
@@ -19484,14 +19595,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>669311d2-e782-3ef5-8ded-ce14320284f1</id>
-            <updated>2022-11-16T11:48:39.443+01:00</updated>
+            <updated>2022-11-17T09:39:42.398+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/38643629-EB5A-41F1-82A5-3471433AEFDD/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>e2de0e89-164a-3491-863c-b58f97deb778</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.464+01:00</published>
+                <published>2022-11-17T09:39:42.419+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/38643629-EB5A-41F1-82A5-3471433AEFDD/ClientNetworkAdapter/e2de0e89-164a-3491-863c-b58f97deb778"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19528,7 +19639,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1813FE39-F124-4415-8767-4997C6C24F9C/ClientNetworkAdapter
@@ -19568,14 +19679,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>c002437e-f726-3cc2-bacb-dddfd5da641c</id>
-            <updated>2022-11-16T11:48:39.509+01:00</updated>
+            <updated>2022-11-17T09:39:42.466+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1813FE39-F124-4415-8767-4997C6C24F9C/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>7b8fbf5c-3799-34b6-b59b-23a1b49db22e</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.529+01:00</published>
+                <published>2022-11-17T09:39:42.485+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1813FE39-F124-4415-8767-4997C6C24F9C/ClientNetworkAdapter/7b8fbf5c-3799-34b6-b59b-23a1b49db22e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19612,7 +19723,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4BB4CBFD-7236-4BE8-934A-1AD6245C6261/ClientNetworkAdapter
@@ -19652,14 +19763,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>94565097-16f9-36dc-8d11-33be2d96bded</id>
-            <updated>2022-11-16T11:48:39.575+01:00</updated>
+            <updated>2022-11-17T09:39:42.534+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4BB4CBFD-7236-4BE8-934A-1AD6245C6261/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>f63d138a-d02f-3d81-ab19-d9413e18e67a</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.595+01:00</published>
+                <published>2022-11-17T09:39:42.555+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4BB4CBFD-7236-4BE8-934A-1AD6245C6261/ClientNetworkAdapter/f63d138a-d02f-3d81-ab19-d9413e18e67a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19696,7 +19807,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:24 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/40AFE87B-0DAB-4B05-9267-5A18295DF4F0/ClientNetworkAdapter
@@ -19736,14 +19847,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>16d4ea2c-5e50-38d4-821d-66d05e531302</id>
-            <updated>2022-11-16T11:48:39.644+01:00</updated>
+            <updated>2022-11-17T09:39:42.605+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/40AFE87B-0DAB-4B05-9267-5A18295DF4F0/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>6a30f049-4aa8-3498-a45e-911e38ef9232</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.665+01:00</published>
+                <published>2022-11-17T09:39:42.625+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/40AFE87B-0DAB-4B05-9267-5A18295DF4F0/ClientNetworkAdapter/6a30f049-4aa8-3498-a45e-911e38ef9232"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19780,7 +19891,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/575E866B-6B4F-4E9D-8B26-F72DE6389703/ClientNetworkAdapter
@@ -19820,14 +19931,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>9d1a1652-a1b1-3ff4-935c-0a3db53a2bbc</id>
-            <updated>2022-11-16T11:48:39.711+01:00</updated>
+            <updated>2022-11-17T09:39:42.675+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/575E866B-6B4F-4E9D-8B26-F72DE6389703/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>ed7abffe-62b3-34f8-82db-96f8936ebda9</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.732+01:00</published>
+                <published>2022-11-17T09:39:42.696+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/575E866B-6B4F-4E9D-8B26-F72DE6389703/ClientNetworkAdapter/ed7abffe-62b3-34f8-82db-96f8936ebda9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -19864,92 +19975,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
-- request:
-    method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session: xxx
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Powered-By:
-      - Servlet/3.0
-      Content-Type:
-      - application/atom+xml
-      Etag:
-      - "-334069196"
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      X-Hmc-Schema-Version:
-      - V1_5_0
-      Content-Length:
-      - '3368'
-      Cache-Control:
-      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
-    body:
-      encoding: UTF-8
-      string: |2
-
-        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>73b49412-0de4-3ecc-9294-d9bb75a214d5</id>
-            <updated>2022-11-16T11:48:39.778+01:00</updated>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter"/>
-            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
-            <generator>IBM Power Systems Management Console</generator>
-            <entry>
-                <id>56639748-8ecc-3726-811e-59b4e173e28d</id>
-                <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.799+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter/56639748-8ecc-3726-811e-59b4e173e28d"/>
-                <author>
-                    <name>IBM Power Systems Management Console</name>
-                </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-334069227</etag:etag>
-                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
-                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
-            <Metadata>
-                <Atom>
-                    <AtomID>56639748-8ecc-3726-811e-59b4e173e28d</AtomID>
-                    <AtomCreated>1668431880650</AtomCreated>
-                </Atom>
-            </Metadata>
-            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V22-C2</DynamicReconfigurationConnectorName>
-            <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V22-C2</LocationCode>
-            <LocalPartitionID kxe="false" kb="CUR">22</LocalPartitionID>
-            <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">true</VariedOn>
-            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
-            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
-            <MACAddress kxe="false" kb="CUR">22ED802D0E02</MACAddress>
-            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
-            <QualityOfServicePriority kxe="false" kb="CUD">0</QualityOfServicePriority>
-            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">true</QualityOfServicePriorityEnabled>
-            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
-            <AssociatedVirtualSwitch kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48" rel="related"/>
-            </AssociatedVirtualSwitch>
-            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
-            <VirtualNetworks kxe="false" kb="CUR">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8" rel="related"/>
-            </VirtualNetworks>
-        </ClientNetworkAdapter:ClientNetworkAdapter>
-                </content>
-            </entry>
-        </feed>
-    http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:26 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5/ClientNetworkAdapter
@@ -19989,14 +20015,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>d655373e-5754-30db-81d4-ff04f5ae8838</id>
-            <updated>2022-11-16T11:48:39.844+01:00</updated>
+            <updated>2022-11-17T09:39:42.744+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>d1466d4c-2198-3e79-a318-38faa4c14b3b</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.866+01:00</published>
+                <published>2022-11-17T09:39:42.766+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5/ClientNetworkAdapter/d1466d4c-2198-3e79-a318-38faa4c14b3b"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20035,7 +20061,7 @@ http_interactions:
             <entry>
                 <id>73372a82-5d68-34a0-b950-e383b6ed3b43</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.867+01:00</published>
+                <published>2022-11-17T09:39:42.767+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5/ClientNetworkAdapter/73372a82-5d68-34a0-b950-e383b6ed3b43"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20074,7 +20100,7 @@ http_interactions:
             <entry>
                 <id>b84bceff-301a-3aa5-9cc6-baa781abe044</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.868+01:00</published>
+                <published>2022-11-17T09:39:42.767+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2C36105C-7547-49DC-BEB0-3753552506C5/ClientNetworkAdapter/b84bceff-301a-3aa5-9cc6-baa781abe044"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20111,7 +20137,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/0611F373-2215-4103-9D05-8E162E67ADBD/ClientNetworkAdapter
@@ -20151,14 +20177,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>049962f9-b218-33f5-863c-8cb59d354f2d</id>
-            <updated>2022-11-16T11:48:39.941+01:00</updated>
+            <updated>2022-11-17T09:39:42.832+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/0611F373-2215-4103-9D05-8E162E67ADBD/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>74e9dbbd-b4b9-3622-a13e-ccdd55afb5e9</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:39.962+01:00</published>
+                <published>2022-11-17T09:39:42.852+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/0611F373-2215-4103-9D05-8E162E67ADBD/ClientNetworkAdapter/74e9dbbd-b4b9-3622-a13e-ccdd55afb5e9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20195,7 +20221,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter
@@ -20235,14 +20261,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>c3170c58-b788-3572-8f33-4e7e86eaf3cb</id>
-            <updated>2022-11-16T11:48:40.007+01:00</updated>
+            <updated>2022-11-17T09:39:42.901+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>246855ec-9d32-38af-aca5-644c04cdae95</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.028+01:00</published>
+                <published>2022-11-17T09:39:42.922+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter/246855ec-9d32-38af-aca5-644c04cdae95"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20279,7 +20305,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/ClientNetworkAdapter
@@ -20319,14 +20345,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>6235d777-99d2-3122-bca6-f4c7f7201d60</id>
-            <updated>2022-11-16T11:48:40.074+01:00</updated>
+            <updated>2022-11-17T09:39:42.970+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>70f053eb-39f6-3c5d-b2e2-4237990de986</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.095+01:00</published>
+                <published>2022-11-17T09:39:42.991+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/ClientNetworkAdapter/70f053eb-39f6-3c5d-b2e2-4237990de986"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20363,7 +20389,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter
@@ -20403,14 +20429,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>8af8e120-8c21-3028-872e-fed5d6ccb149</id>
-            <updated>2022-11-16T11:48:40.140+01:00</updated>
+            <updated>2022-11-17T09:39:43.038+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>81be3e5e-f516-37d1-8737-e5f57c7f93d7</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.160+01:00</published>
+                <published>2022-11-17T09:39:43.058+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter/81be3e5e-f516-37d1-8737-e5f57c7f93d7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20447,7 +20473,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/264C3673-F340-4D79-9AC7-5FD6E3293C44/ClientNetworkAdapter
@@ -20487,14 +20513,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>bdfcdfa6-5b3c-3cef-94dd-7e6bf61d52ab</id>
-            <updated>2022-11-16T11:48:40.206+01:00</updated>
+            <updated>2022-11-17T09:39:43.107+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/264C3673-F340-4D79-9AC7-5FD6E3293C44/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>a8fe51df-0418-3182-8227-aca89e74a980</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.226+01:00</published>
+                <published>2022-11-17T09:39:43.128+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/264C3673-F340-4D79-9AC7-5FD6E3293C44/ClientNetworkAdapter/a8fe51df-0418-3182-8227-aca89e74a980"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20531,7 +20557,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/242BA00C-AF20-49E3-AF71-704922DDD4DA/ClientNetworkAdapter
@@ -20571,14 +20597,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>063ffed8-0f45-3876-a87e-98bfa6ebf64c</id>
-            <updated>2022-11-16T11:48:40.271+01:00</updated>
+            <updated>2022-11-17T09:39:43.178+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/242BA00C-AF20-49E3-AF71-704922DDD4DA/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>c6d741ed-782a-33c2-9408-ad63691a044f</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.291+01:00</published>
+                <published>2022-11-17T09:39:43.198+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/242BA00C-AF20-49E3-AF71-704922DDD4DA/ClientNetworkAdapter/c6d741ed-782a-33c2-9408-ad63691a044f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20615,7 +20641,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2B3795A9-AD12-4887-95AE-691E80611E4F/ClientNetworkAdapter
@@ -20655,14 +20681,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>3c2d9e3a-2992-3f07-99d1-c40f4f1d155e</id>
-            <updated>2022-11-16T11:48:40.337+01:00</updated>
+            <updated>2022-11-17T09:39:43.245+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2B3795A9-AD12-4887-95AE-691E80611E4F/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>a03bdd77-7087-310d-a817-36fb2d630807</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.358+01:00</published>
+                <published>2022-11-17T09:39:43.266+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2B3795A9-AD12-4887-95AE-691E80611E4F/ClientNetworkAdapter/a03bdd77-7087-310d-a817-36fb2d630807"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20699,7 +20725,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3BD7BF62-1ED0-4AF1-A605-D8E6A9FACDD9/ClientNetworkAdapter
@@ -20739,14 +20765,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>03451672-88e7-3d7b-8dac-8743d1d23e05</id>
-            <updated>2022-11-16T11:48:40.403+01:00</updated>
+            <updated>2022-11-17T09:39:43.316+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3BD7BF62-1ED0-4AF1-A605-D8E6A9FACDD9/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>2451b01a-3f96-353e-b22a-1af5536c4202</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.423+01:00</published>
+                <published>2022-11-17T09:39:43.354+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/3BD7BF62-1ED0-4AF1-A605-D8E6A9FACDD9/ClientNetworkAdapter/2451b01a-3f96-353e-b22a-1af5536c4202"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20783,7 +20809,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2D5E4DBF-5294-493F-9F0C-A1D4776F10D2/ClientNetworkAdapter
@@ -20823,14 +20849,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>ddc38257-e8e4-3f99-a146-38e18a6c5ad1</id>
-            <updated>2022-11-16T11:48:40.469+01:00</updated>
+            <updated>2022-11-17T09:39:43.409+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2D5E4DBF-5294-493F-9F0C-A1D4776F10D2/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>73d964a9-ff79-3c9e-a31e-74bc8d6af5d2</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.490+01:00</published>
+                <published>2022-11-17T09:39:43.429+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/2D5E4DBF-5294-493F-9F0C-A1D4776F10D2/ClientNetworkAdapter/73d964a9-ff79-3c9e-a31e-74bc8d6af5d2"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20867,7 +20893,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18CF2B4F-BE3D-4CF4-A28C-1483D89DCB9F/ClientNetworkAdapter
@@ -20907,14 +20933,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>32761e4d-e1f4-3030-9b26-f38438ff79dd</id>
-            <updated>2022-11-16T11:48:40.535+01:00</updated>
+            <updated>2022-11-17T09:39:43.478+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18CF2B4F-BE3D-4CF4-A28C-1483D89DCB9F/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>45cfcd0d-4ec9-3eb9-a694-472cce01c871</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.555+01:00</published>
+                <published>2022-11-17T09:39:43.498+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18CF2B4F-BE3D-4CF4-A28C-1483D89DCB9F/ClientNetworkAdapter/45cfcd0d-4ec9-3eb9-a694-472cce01c871"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -20951,92 +20977,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
-- request:
-    method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session: xxx
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Powered-By:
-      - Servlet/3.0
-      Content-Type:
-      - application/atom+xml
-      Etag:
-      - "-2140642926"
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      X-Hmc-Schema-Version:
-      - V1_5_0
-      Content-Length:
-      - '3369'
-      Cache-Control:
-      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
-    body:
-      encoding: UTF-8
-      string: |2
-
-        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>82bf88a7-8e81-38c2-81f2-e606118dba40</id>
-            <updated>2022-11-16T11:48:40.614+01:00</updated>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter"/>
-            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
-            <generator>IBM Power Systems Management Console</generator>
-            <entry>
-                <id>25c1ba09-7f19-3865-a83d-ec672d0237aa</id>
-                <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.634+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter/25c1ba09-7f19-3865-a83d-ec672d0237aa"/>
-                <author>
-                    <name>IBM Power Systems Management Console</name>
-                </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-2140642957</etag:etag>
-                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
-                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
-            <Metadata>
-                <Atom>
-                    <AtomID>25c1ba09-7f19-3865-a83d-ec672d0237aa</AtomID>
-                    <AtomCreated>1668431881545</AtomCreated>
-                </Atom>
-            </Metadata>
-            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V10-C2</DynamicReconfigurationConnectorName>
-            <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V10-C2</LocationCode>
-            <LocalPartitionID kxe="false" kb="CUR">10</LocalPartitionID>
-            <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">true</VariedOn>
-            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
-            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
-            <MACAddress kxe="false" kb="CUR">22ED8263CE02</MACAddress>
-            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
-            <QualityOfServicePriority kxe="false" kb="CUD">0</QualityOfServicePriority>
-            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">true</QualityOfServicePriorityEnabled>
-            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
-            <AssociatedVirtualSwitch kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48" rel="related"/>
-            </AssociatedVirtualSwitch>
-            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
-            <VirtualNetworks kxe="false" kb="CUR">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8" rel="related"/>
-            </VirtualNetworks>
-        </ClientNetworkAdapter:ClientNetworkAdapter>
-                </content>
-            </entry>
-        </feed>
-    http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:25 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/ClientNetworkAdapter
@@ -21076,14 +21017,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>89104412-efce-3857-9796-4545310edd09</id>
-            <updated>2022-11-16T11:48:40.680+01:00</updated>
+            <updated>2022-11-17T09:39:43.550+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>8fa4f3d2-92c8-3b2c-a113-106a1cb79a81</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.701+01:00</published>
+                <published>2022-11-17T09:39:43.570+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/ClientNetworkAdapter/8fa4f3d2-92c8-3b2c-a113-106a1cb79a81"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -21120,7 +21061,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:26 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6F67D796-80BA-457F-9E81-2B307A484294/ClientNetworkAdapter
@@ -21160,14 +21101,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>33a0bed5-f1a1-3d16-8597-1f6e02b7b795</id>
-            <updated>2022-11-16T11:48:40.747+01:00</updated>
+            <updated>2022-11-17T09:39:43.621+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6F67D796-80BA-457F-9E81-2B307A484294/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>ad9c69c3-33fb-351f-aee9-c7c4664a3860</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.767+01:00</published>
+                <published>2022-11-17T09:39:43.656+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6F67D796-80BA-457F-9E81-2B307A484294/ClientNetworkAdapter/ad9c69c3-33fb-351f-aee9-c7c4664a3860"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -21204,7 +21145,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:26 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7D1DAADD-36EF-4D78-95EE-1E9B8C656DA1/ClientNetworkAdapter
@@ -21244,14 +21185,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>6321707f-b12a-33f2-aa96-a67458e0d93a</id>
-            <updated>2022-11-16T11:48:40.813+01:00</updated>
+            <updated>2022-11-17T09:39:43.705+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7D1DAADD-36EF-4D78-95EE-1E9B8C656DA1/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>8ed8ceae-939f-3726-bdc2-5215b184f847</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.834+01:00</published>
+                <published>2022-11-17T09:39:43.725+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7D1DAADD-36EF-4D78-95EE-1E9B8C656DA1/ClientNetworkAdapter/8ed8ceae-939f-3726-bdc2-5215b184f847"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -21288,7 +21229,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:26 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:27 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/40381833-1012-44B9-8455-E2D6B9BD00EE/ClientNetworkAdapter
@@ -21328,14 +21269,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>a7d62796-8b2f-34eb-8033-4de4c2840be9</id>
-            <updated>2022-11-16T11:48:40.878+01:00</updated>
+            <updated>2022-11-17T09:39:43.775+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/40381833-1012-44B9-8455-E2D6B9BD00EE/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>8cc3a143-bccc-35c0-a7c5-0e1589658314</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.898+01:00</published>
+                <published>2022-11-17T09:39:43.796+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/40381833-1012-44B9-8455-E2D6B9BD00EE/ClientNetworkAdapter/8cc3a143-bccc-35c0-a7c5-0e1589658314"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -21372,7 +21313,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:26 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:28 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257/ClientNetworkAdapter
@@ -21412,14 +21353,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>7f01537c-76b0-3691-a955-b912e287e9c4</id>
-            <updated>2022-11-16T11:48:40.946+01:00</updated>
+            <updated>2022-11-17T09:39:43.845+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>edb2b83a-c838-36fa-a2b0-4b069bfdd99a</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:40.967+01:00</published>
+                <published>2022-11-17T09:39:43.865+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257/ClientNetworkAdapter/edb2b83a-c838-36fa-a2b0-4b069bfdd99a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -21456,7 +21397,177 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:26 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:28 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - "-334069196"
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '3368'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>73b49412-0de4-3ecc-9294-d9bb75a214d5</id>
+            <updated>2022-11-17T09:39:43.915+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>56639748-8ecc-3726-811e-59b4e173e28d</id>
+                <title>ClientNetworkAdapter</title>
+                <published>2022-11-17T09:39:43.935+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter/56639748-8ecc-3726-811e-59b4e173e28d"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-334069227</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
+                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>56639748-8ecc-3726-811e-59b4e173e28d</AtomID>
+                    <AtomCreated>1668431880650</AtomCreated>
+                </Atom>
+            </Metadata>
+            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V22-C2</DynamicReconfigurationConnectorName>
+            <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V22-C2</LocationCode>
+            <LocalPartitionID kxe="false" kb="CUR">22</LocalPartitionID>
+            <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
+            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
+            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
+            <MACAddress kxe="false" kb="CUR">22ED802D0E02</MACAddress>
+            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
+            <QualityOfServicePriority kxe="false" kb="CUD">0</QualityOfServicePriority>
+            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">true</QualityOfServicePriorityEnabled>
+            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
+            <AssociatedVirtualSwitch kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48" rel="related"/>
+            </AssociatedVirtualSwitch>
+            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
+            <VirtualNetworks kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8" rel="related"/>
+            </VirtualNetworks>
+        </ClientNetworkAdapter:ClientNetworkAdapter>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:08:28 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - "-2140642926"
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '3369'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>82bf88a7-8e81-38c2-81f2-e606118dba40</id>
+            <updated>2022-11-17T09:39:43.985+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>25c1ba09-7f19-3865-a83d-ec672d0237aa</id>
+                <title>ClientNetworkAdapter</title>
+                <published>2022-11-17T09:39:44.005+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/18278B69-2634-4697-AAD0-CC6BCA022507/ClientNetworkAdapter/25c1ba09-7f19-3865-a83d-ec672d0237aa"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-2140642957</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
+                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>25c1ba09-7f19-3865-a83d-ec672d0237aa</AtomID>
+                    <AtomCreated>1668431881545</AtomCreated>
+                </Atom>
+            </Metadata>
+            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V10-C2</DynamicReconfigurationConnectorName>
+            <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V10-C2</LocationCode>
+            <LocalPartitionID kxe="false" kb="CUR">10</LocalPartitionID>
+            <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
+            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
+            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
+            <MACAddress kxe="false" kb="CUR">22ED8263CE02</MACAddress>
+            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
+            <QualityOfServicePriority kxe="false" kb="CUD">0</QualityOfServicePriority>
+            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">true</QualityOfServicePriorityEnabled>
+            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
+            <AssociatedVirtualSwitch kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48" rel="related"/>
+            </AssociatedVirtualSwitch>
+            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
+            <VirtualNetworks kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8" rel="related"/>
+            </VirtualNetworks>
+        </ClientNetworkAdapter:ClientNetworkAdapter>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:08:28 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer?ignoreError=true
@@ -21481,7 +21592,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - '456943464'
+      - "-342917715"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -21496,14 +21607,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>2d92f5ca-70da-3d65-82cb-ea49a840c7ff</id>
-            <updated>2022-11-16T11:48:41.013+01:00</updated>
+            <updated>2022-11-17T09:39:44.054+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer?ignoreError=true"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>1ABB7000-4A15-4749-9EAE-CD0A0827CDFE</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:43.517+01:00</published>
+                <published>2022-11-17T09:39:44.593+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -22906,12 +23017,12 @@ http_interactions:
             <entry>
                 <id>0D323064-36E2-455A-AB06-46BD079AD545</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:43.531+01:00</published>
+                <published>2022-11-17T09:39:44.607+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/0D323064-36E2-455A-AB06-46BD079AD545?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1789638222</etag:etag>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1705467895</etag:etag>
                 <content type="application/vnd.ibm.powervm.uom+xml; type=VirtualIOServer">
                     <VirtualIOServer:VirtualIOServer xmlns:VirtualIOServer="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
@@ -23220,7 +23331,7 @@ http_interactions:
                     <ReservePolicy kb="CUD" kxe="false">NoReserve</ReservePolicy>
                     <ReservePolicyAlgorithm kb="CUD" kxe="false">Failover</ReservePolicyAlgorithm>
                     <UniqueDeviceID kb="ROR" kxe="false">01M0lCTTIxNDU1MjQ2MDA1MDc2NDAwODEwMERDNDgwMDAwMDAwMDAwMkMwNg==</UniqueDeviceID>
-                    <AvailableForUsage kxe="false" kb="CUD">true</AvailableForUsage>
+                    <AvailableForUsage kxe="false" kb="CUD">false</AvailableForUsage>
                     <VolumeCapacity kb="CUR" kxe="false">102400</VolumeCapacity>
                     <VolumeName kb="CUR" kxe="false">hdisk5</VolumeName>
                     <VolumeState kxe="false" kb="ROR">active</VolumeState>
@@ -23726,7 +23837,7 @@ http_interactions:
                     <ReservePolicy kb="CUD" kxe="false">NoReserve</ReservePolicy>
                     <ReservePolicyAlgorithm kb="CUD" kxe="false">Failover</ReservePolicyAlgorithm>
                     <UniqueDeviceID kb="ROR" kxe="false">01M0lCTTIxNDU1MjQ2MDA1MDc2NDAwODEwMERDNDgwMDAwMDAwMDAwMkMwNg==</UniqueDeviceID>
-                    <AvailableForUsage kxe="false" kb="CUD">true</AvailableForUsage>
+                    <AvailableForUsage kxe="false" kb="CUD">false</AvailableForUsage>
                     <VolumeCapacity kb="CUR" kxe="false">102400</VolumeCapacity>
                     <VolumeName kb="CUR" kxe="false">hdisk5</VolumeName>
                     <VolumeState kxe="false" kb="ROR">active</VolumeState>
@@ -24778,7 +24889,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:28 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:28 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer?ignoreError=true
@@ -24818,14 +24929,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>26434a42-ed8d-3647-b5de-52120a567d48</id>
-            <updated>2022-11-16T11:48:44.011+01:00</updated>
+            <updated>2022-11-17T09:39:45.069+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer?ignoreError=true"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>12F4DFC3-8D5E-42B2-B34A-E1D4EF55FE0A</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:46.239+01:00</published>
+                <published>2022-11-17T09:39:45.517+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer/12F4DFC3-8D5E-42B2-B34A-E1D4EF55FE0A?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -25136,7 +25247,7 @@ http_interactions:
             <entry>
                 <id>722B9A3A-15DC-4BE1-AAFE-ED5D17C70371</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:46.242+01:00</published>
+                <published>2022-11-17T09:39:45.520+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -25436,7 +25547,7 @@ http_interactions:
             <entry>
                 <id>287ED600-69A9-407A-B2CF-86057C0F7A68</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:46.244+01:00</published>
+                <published>2022-11-17T09:39:45.523+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer/287ED600-69A9-407A-B2CF-86057C0F7A68?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -25695,7 +25806,7 @@ http_interactions:
             <entry>
                 <id>4154B185-22EB-4D16-B1F4-D9F714496C98</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:46.259+01:00</published>
+                <published>2022-11-17T09:39:45.538+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer/4154B185-22EB-4D16-B1F4-D9F714496C98?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -27599,7 +27710,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:31 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:29 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer?ignoreError=true
@@ -27624,7 +27735,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-744025877"
+      - "-1965798207"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -27639,289 +27750,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>fbb5400d-5b31-3959-8897-17a2e4684b0c</id>
-            <updated>2022-11-16T11:48:46.750+01:00</updated>
+            <updated>2022-11-17T09:39:45.996+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer?ignoreError=true"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
-                <id>785FB584-AA40-460D-8803-A38AA0271030</id>
-                <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:48.818+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030?ignoreError=true"/>
-                <author>
-                    <name>IBM Power Systems Management Console</name>
-                </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">783253321</etag:etag>
-                <content type="application/vnd.ibm.powervm.uom+xml; type=VirtualIOServer">
-                    <VirtualIOServer:VirtualIOServer xmlns:VirtualIOServer="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
-            <Metadata>
-                <Atom>
-                    <AtomID>785FB584-AA40-460D-8803-A38AA0271030</AtomID>
-                    <AtomCreated>1667815509993</AtomCreated>
-                </Atom>
-            </Metadata>
-            <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
-            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/LogicalPartitionProfile/ca05d361-8360-3bdc-926b-e677292e458c" rel="related"/>
-            <AvailabilityPriority kxe="false" kb="UOD">191</AvailabilityPriority>
-            <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
-            <CurrentProfileSync kb="CUD" kxe="false">Disabled</CurrentProfileSync>
-            <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
-            <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
-            <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
-            <IsRedundantErrorPathReportingEnabled kb="UOD" kxe="false">false</IsRedundantErrorPathReportingEnabled>
-            <IsTimeReferencePartition kb="UOD" kxe="false">false</IsTimeReferencePartition>
-            <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
-            <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
-            <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
-            <LogicalSerialNumber kxe="false" kb="ROR">214D29V3</LogicalSerialNumber>
-            <OperatingSystemVersion kb="ROR" kxe="false">VIOS </OperatingSystemVersion>
-            <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
-                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
-                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
-                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
-                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
-            </PartitionCapabilities>
-            <PartitionID kxe="false" kb="COD">3</PartitionID>
-            <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <MaximumVirtualIOSlots kb="CUD" kxe="false">10</MaximumVirtualIOSlots>
-                <ProfileIOSlots kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <ProfileIOSlot schemaVersion="V1_5_0">
-                        <Metadata>
-                            <Atom/>
-                        </Metadata>
-                        <AssociatedIOSlot kxe="false" kb="CUD" schemaVersion="V1_5_0">
-                            <Metadata>
-                                <Atom/>
-                            </Metadata>
-                            <BusGroupingRequired kb="CUD" kxe="false">false</BusGroupingRequired>
-                            <Description kb="CUD" kxe="false">8 Gigabit PCI Express Dual Port Fibre Channel Adapter</Description>
-                            <FeatureCodes kb="ROO" kxe="false">5735</FeatureCodes>
-                            <FeatureCodes kb="ROO" kxe="false">5735</FeatureCodes>
-                            <FeatureCodes kb="ROO" kxe="false">5735</FeatureCodes>
-                            <IOUnitPhysicalLocation kb="ROR" kxe="false">U78C9.001.WZS01L9</IOUnitPhysicalLocation>
-                            <PartitionID ksv="V1_3_0" kb="ROO" kxe="false">3</PartitionID>
-                            <PartitionName ksv="V1_3_0" kxe="false" kb="ROO">aramis-vios2</PartitionName>
-                            <PartitionType ksv="V1_3_0" kxe="false" kb="ROO">Virtual IO Server</PartitionType>
-                            <PCAdapterID kb="ROO" kxe="false">61696</PCAdapterID>
-                            <PCIClass kxe="false" kb="ROO">3076</PCIClass>
-                            <PCIDeviceID kb="ROO" kxe="false">61696</PCIDeviceID>
-                            <PCISubsystemDeviceID kxe="false" kb="ROO">906</PCISubsystemDeviceID>
-                            <PCIManufacturerID kxe="false" kb="ROO">4319</PCIManufacturerID>
-                            <PCIRevisionID kxe="false" kb="ROO">3</PCIRevisionID>
-                            <PCIVendorID kb="ROO" kxe="false">4319</PCIVendorID>
-                            <PCISubsystemVendorID kxe="false" kb="ROO">4116</PCISubsystemVendorID>
-                            <RelatedIBMiIOSlot kxe="false" kb="CUD" schemaVersion="V1_5_0">
-                                <Metadata>
-                                    <Atom/>
-                                </Metadata>
-                                <AlternateLoadSourceAttached kb="ROR" kxe="false">false</AlternateLoadSourceAttached>
-                                <ConsoleCapable kxe="false" kb="ROR">false</ConsoleCapable>
-                                <DirectOperationsConsoleCapable kxe="false" kb="ROR">false</DirectOperationsConsoleCapable>
-                                <IOP kb="ROR" kxe="false">false</IOP>
-                                <IOPInfoStale kxe="false" kb="ROR">false</IOPInfoStale>
-                                <IOPoolID kb="ROR" kxe="false">65535</IOPoolID>
-                                <LANConsoleCapable kb="ROR" kxe="false">false</LANConsoleCapable>
-                                <LoadSourceAttached kxe="false" kb="ROR">false</LoadSourceAttached>
-                                <LoadSourceCapable kb="ROR" kxe="false">false</LoadSourceCapable>
-                                <OperationsConsoleAttached kxe="false" kb="ROR">false</OperationsConsoleAttached>
-                                <OperationsConsoleCapable kb="ROR" kxe="false">false</OperationsConsoleCapable>
-                            </RelatedIBMiIOSlot>
-                            <RelatedIOAdapter kxe="false" kb="CUD">
-                                <IOAdapter schemaVersion="V1_5_0">
-                                    <Metadata>
-        <Atom/>
-                                    </Metadata>
-                                    <AdapterID kb="ROR" kxe="false">553713697</AdapterID>
-                                    <Description kxe="false" kb="CUD">8 Gigabit PCI Express Dual Port Fibre Channel Adapter</Description>
-                                    <DeviceName kb="ROR" kxe="false">U78C9.001.WZS01L9-P1-C5</DeviceName>
-                                    <DynamicReconfigurationConnectorName kxe="false" kb="CUD">U78C9.001.WZS01L9-P1-C5</DynamicReconfigurationConnectorName>
-                                    <PhysicalLocation kb="ROR" kxe="false">C5</PhysicalLocation>
-                                    <UniqueDeviceID kb="ROR" kxe="false">61696</UniqueDeviceID>
-                                    <LogicalPartitionAssignmentCapable ksv="V1_2_0" kb="ROO" kxe="false">true</LogicalPartitionAssignmentCapable>
-                                    <DynamicPartitionAssignmentCapable ksv="V1_3_0" kb="ROR" kxe="false">true</DynamicPartitionAssignmentCapable>
-                                </IOAdapter>
-                            </RelatedIOAdapter>
-                            <SlotDynamicReconfigurationConnectorIndex kb="ROR" kxe="false">553713697</SlotDynamicReconfigurationConnectorIndex>
-                            <SlotDynamicReconfigurationConnectorName kxe="false" kb="CUD">U78C9.001.WZS01L9-P1-C5</SlotDynamicReconfigurationConnectorName>
-                            <SlotPhysicalLocationCode kb="ROR" kxe="false">C5</SlotPhysicalLocationCode>
-                            <SRIOVCapableDevice ksv="V1_3_0" kxe="false" kb="ROO">false</SRIOVCapableDevice>
-                            <SRIOVCapableSlot ksv="V1_3_0" kxe="false" kb="ROO">true</SRIOVCapableSlot>
-                            <SRIOVLogicalPortsLimit ksv="V1_3_0" kxe="false" kb="ROO">120</SRIOVLogicalPortsLimit>
-                        </AssociatedIOSlot>
-                    </ProfileIOSlot>
-                </ProfileIOSlots>
-                <CurrentMaximumVirtualIOSlots kxe="false" kb="ROR">10</CurrentMaximumVirtualIOSlots>
-            </PartitionIOConfiguration>
-            <PartitionMemoryConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
-                <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
-                <DesiredMemory kxe="false" kb="CUD">10240</DesiredMemory>
-                <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
-                <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
-                <MaximumMemory kb="CUD" kxe="false">10240</MaximumMemory>
-                <MinimumMemory kb="CUD" kxe="false">5120</MinimumMemory>
-                <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
-                <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
-                <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
-                <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
-                <CurrentMaximumMemory kxe="false" kb="ROR">10240</CurrentMaximumMemory>
-                <CurrentMemory kb="ROR" kxe="false">10240</CurrentMemory>
-                <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
-                <CurrentMinimumMemory kxe="false" kb="ROR">5120</CurrentMinimumMemory>
-                <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
-                <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
-                <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
-                <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
-                <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
-                <RuntimeMemory kxe="false" kb="ROR">256</RuntimeMemory>
-                <RuntimeMinimumMemory kxe="false" kb="ROR">5120</RuntimeMinimumMemory>
-                <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
-            </PartitionMemoryConfiguration>
-            <PartitionName kb="CUR" kxe="false">aramis-vios2</PartitionName>
-            <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
-                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <DesiredProcessingUnits kxe="false" kb="CUD">0.4</DesiredProcessingUnits>
-                    <DesiredVirtualProcessors kb="CUD" kxe="false">1</DesiredVirtualProcessors>
-                    <MaximumProcessingUnits kxe="false" kb="CUD">1.5</MaximumProcessingUnits>
-                    <MaximumVirtualProcessors kxe="false" kb="CUD">2</MaximumVirtualProcessors>
-                    <MinimumProcessingUnits kb="CUD" kxe="false">0.2</MinimumProcessingUnits>
-                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
-                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
-                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
-                </SharedProcessorConfiguration>
-                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
-                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
-                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
-                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
-                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <AllocatedVirtualProcessors kxe="false" kb="ROR">1</AllocatedVirtualProcessors>
-                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">1.5</CurrentMaximumProcessingUnits>
-                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.2</CurrentMinimumProcessingUnits>
-                    <CurrentProcessingUnits kxe="false" kb="ROR">0.4</CurrentProcessingUnits>
-                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
-                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
-                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
-                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">2</CurrentMaximumVirtualProcessors>
-                    <RuntimeProcessingUnits kxe="false" kb="ROR">0</RuntimeProcessingUnits>
-                    <RuntimeUncappedWeight kb="ROR" kxe="false">0</RuntimeUncappedWeight>
-                </CurrentSharedProcessorConfiguration>
-            </PartitionProcessorConfiguration>
-            <PartitionProfiles kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/LogicalPartitionProfile/ca05d361-8360-3bdc-926b-e677292e458c" rel="related"/>
-            </PartitionProfiles>
-            <PartitionState kxe="false" kb="ROO">not activated</PartitionState>
-            <PartitionType kb="COD" kxe="false">Virtual IO Server</PartitionType>
-            <PartitionUUID kxe="false" kb="ROO">785FB584-AA40-460D-8803-A38AA0271030</PartitionUUID>
-            <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
-            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
-            <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
-            <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
-            <ResourceMonitoringIPAddress kb="CUD" kxe="false">10.197.64.116</ResourceMonitoringIPAddress>
-            <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
-            <ClientNetworkAdapters kxe="false" kb="CUR">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter/dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb" rel="related"/>
-            </ClientNetworkAdapters>
-            <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-            </HostEthernetAdapterLogicalPorts>
-            <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
-            <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
-            <ReferenceCode kb="ROO" kxe="true">00000000</ReferenceCode>
-            <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
-            <APICapable kb="CUD" kxe="false">false</APICapable>
-            <IsVNICCapable ksv="V1_3_0" kxe="false" kb="CUD">false</IsVNICCapable>
-            <VNICFailOverCapable ksv="V1_4_0" kxe="false" kb="CUD">false</VNICFailOverCapable>
-            <ManagerPassthroughCapable kxe="false" kb="CUD">false</ManagerPassthroughCapable>
-            <MoverServicePartition kxe="false" kb="CUD">true</MoverServicePartition>
-            <TrunkAdapters group="ViosNetwork" kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-            </TrunkAdapters>
-            <VirtualFibreChannelMappings group="ViosFCMapping" kxe="false" kb="CUD" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-            </VirtualFibreChannelMappings>
-            <VirtualSCSIMappings group="ViosSCSIMapping" kb="CUD" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-                <VirtualSCSIMapping schemaVersion="V1_5_0">
-                    <Metadata>
-                        <Atom/>
-                    </Metadata>
-                    <AssociatedLogicalPartition kxe="false" kb="CUR" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257" rel="related"/>
-                    <ClientAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
-                        <Metadata>
-                            <Atom/>
-                        </Metadata>
-                        <AdapterType kb="ROR" kxe="false">Client</AdapterType>
-                        <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V4-C5</DynamicReconfigurationConnectorName>
-                        <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V4-C5</LocationCode>
-                        <LocalPartitionID kxe="false" kb="CUR">4</LocalPartitionID>
-                        <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
-                        <VirtualSlotNumber kb="COD" kxe="false">5</VirtualSlotNumber>
-                        <RemoteLogicalPartitionID kxe="false" kb="CUR">3</RemoteLogicalPartitionID>
-                        <RemoteSlotNumber kxe="false" kb="CUA">3</RemoteSlotNumber>
-                        <ServerLocationCode kb="CUR" kxe="false">U8286.42A.214D29V-V3-C3</ServerLocationCode>
-                    </ClientAdapter>
-                    <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
-                        <Metadata>
-                            <Atom/>
-                        </Metadata>
-                        <AdapterType kb="ROR" kxe="false">Server</AdapterType>
-                        <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V3-C3</DynamicReconfigurationConnectorName>
-                        <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V3-C3</LocationCode>
-                        <LocalPartitionID kxe="false" kb="CUR">3</LocalPartitionID>
-                        <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
-                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
-                        <VirtualSlotNumber kb="COD" kxe="false">3</VirtualSlotNumber>
-                        <RemoteLogicalPartitionID kxe="false" kb="CUR">4</RemoteLogicalPartitionID>
-                        <RemoteSlotNumber kxe="false" kb="CUA">5</RemoteSlotNumber>
-                        <ServerLocationCode kb="CUR" kxe="false">U8286.42A.214D29V-V4-C5</ServerLocationCode>
-                    </ServerAdapter>
-                </VirtualSCSIMapping>
-            </VirtualSCSIMappings>
-            <VirtualNICBackingDevices group="VNIC" ksv="V1_3_0" kb="ROR" kxe="false" schemaVersion="V1_5_0">
-                <Metadata>
-                    <Atom/>
-                </Metadata>
-            </VirtualNICBackingDevices>
-        </VirtualIOServer:VirtualIOServer>
-                </content>
-            </entry>
-            <entry>
                 <id>0A0DC7D2-42B2-45BD-B63F-22C5290A103C</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:48.821+01:00</published>
+                <published>2022-11-17T09:39:47.672+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/0A0DC7D2-42B2-45BD-B63F-22C5290A103C?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -28263,9 +28099,284 @@ http_interactions:
                 </content>
             </entry>
             <entry>
+                <id>785FB584-AA40-460D-8803-A38AA0271030</id>
+                <title>VirtualIOServer</title>
+                <published>2022-11-17T09:39:47.675+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030?ignoreError=true"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">783253321</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=VirtualIOServer">
+                    <VirtualIOServer:VirtualIOServer xmlns:VirtualIOServer="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>785FB584-AA40-460D-8803-A38AA0271030</AtomID>
+                    <AtomCreated>1667815509993</AtomCreated>
+                </Atom>
+            </Metadata>
+            <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
+            <AssociatedPartitionProfile kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/LogicalPartitionProfile/ca05d361-8360-3bdc-926b-e677292e458c" rel="related"/>
+            <AvailabilityPriority kxe="false" kb="UOD">191</AvailabilityPriority>
+            <CurrentProcessorCompatibilityMode kxe="false" kb="ROO">POWER8</CurrentProcessorCompatibilityMode>
+            <CurrentProfileSync kb="CUD" kxe="false">Disabled</CurrentProfileSync>
+            <IsBootable ksv="V1_3_0" kb="ROO" kxe="false">true</IsBootable>
+            <IsConnectionMonitoringEnabled kxe="false" kb="UOD">true</IsConnectionMonitoringEnabled>
+            <IsOperationInProgress kb="ROR" kxe="false">false</IsOperationInProgress>
+            <IsRedundantErrorPathReportingEnabled kb="UOD" kxe="false">false</IsRedundantErrorPathReportingEnabled>
+            <IsTimeReferencePartition kb="UOD" kxe="false">false</IsTimeReferencePartition>
+            <IsVirtualServiceAttentionLEDOn kxe="false" kb="ROR">false</IsVirtualServiceAttentionLEDOn>
+            <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
+            <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
+            <LogicalSerialNumber kxe="false" kb="ROR">214D29V3</LogicalSerialNumber>
+            <OperatingSystemVersion kb="ROR" kxe="false">VIOS </OperatingSystemVersion>
+            <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
+                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
+                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
+                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
+                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
+            </PartitionCapabilities>
+            <PartitionID kxe="false" kb="COD">3</PartitionID>
+            <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <MaximumVirtualIOSlots kb="CUD" kxe="false">10</MaximumVirtualIOSlots>
+                <ProfileIOSlots kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <ProfileIOSlot schemaVersion="V1_5_0">
+                        <Metadata>
+                            <Atom/>
+                        </Metadata>
+                        <AssociatedIOSlot kxe="false" kb="CUD" schemaVersion="V1_5_0">
+                            <Metadata>
+                                <Atom/>
+                            </Metadata>
+                            <BusGroupingRequired kb="CUD" kxe="false">false</BusGroupingRequired>
+                            <Description kb="CUD" kxe="false">8 Gigabit PCI Express Dual Port Fibre Channel Adapter</Description>
+                            <FeatureCodes kb="ROO" kxe="false">5735</FeatureCodes>
+                            <FeatureCodes kb="ROO" kxe="false">5735</FeatureCodes>
+                            <FeatureCodes kb="ROO" kxe="false">5735</FeatureCodes>
+                            <IOUnitPhysicalLocation kb="ROR" kxe="false">U78C9.001.WZS01L9</IOUnitPhysicalLocation>
+                            <PartitionID ksv="V1_3_0" kb="ROO" kxe="false">3</PartitionID>
+                            <PartitionName ksv="V1_3_0" kxe="false" kb="ROO">aramis-vios2</PartitionName>
+                            <PartitionType ksv="V1_3_0" kxe="false" kb="ROO">Virtual IO Server</PartitionType>
+                            <PCAdapterID kb="ROO" kxe="false">61696</PCAdapterID>
+                            <PCIClass kxe="false" kb="ROO">3076</PCIClass>
+                            <PCIDeviceID kb="ROO" kxe="false">61696</PCIDeviceID>
+                            <PCISubsystemDeviceID kxe="false" kb="ROO">906</PCISubsystemDeviceID>
+                            <PCIManufacturerID kxe="false" kb="ROO">4319</PCIManufacturerID>
+                            <PCIRevisionID kxe="false" kb="ROO">3</PCIRevisionID>
+                            <PCIVendorID kb="ROO" kxe="false">4319</PCIVendorID>
+                            <PCISubsystemVendorID kxe="false" kb="ROO">4116</PCISubsystemVendorID>
+                            <RelatedIBMiIOSlot kxe="false" kb="CUD" schemaVersion="V1_5_0">
+                                <Metadata>
+                                    <Atom/>
+                                </Metadata>
+                                <AlternateLoadSourceAttached kb="ROR" kxe="false">false</AlternateLoadSourceAttached>
+                                <ConsoleCapable kxe="false" kb="ROR">false</ConsoleCapable>
+                                <DirectOperationsConsoleCapable kxe="false" kb="ROR">false</DirectOperationsConsoleCapable>
+                                <IOP kb="ROR" kxe="false">false</IOP>
+                                <IOPInfoStale kxe="false" kb="ROR">false</IOPInfoStale>
+                                <IOPoolID kb="ROR" kxe="false">65535</IOPoolID>
+                                <LANConsoleCapable kb="ROR" kxe="false">false</LANConsoleCapable>
+                                <LoadSourceAttached kxe="false" kb="ROR">false</LoadSourceAttached>
+                                <LoadSourceCapable kb="ROR" kxe="false">false</LoadSourceCapable>
+                                <OperationsConsoleAttached kxe="false" kb="ROR">false</OperationsConsoleAttached>
+                                <OperationsConsoleCapable kb="ROR" kxe="false">false</OperationsConsoleCapable>
+                            </RelatedIBMiIOSlot>
+                            <RelatedIOAdapter kxe="false" kb="CUD">
+                                <IOAdapter schemaVersion="V1_5_0">
+                                    <Metadata>
+        <Atom/>
+                                    </Metadata>
+                                    <AdapterID kb="ROR" kxe="false">553713697</AdapterID>
+                                    <Description kxe="false" kb="CUD">8 Gigabit PCI Express Dual Port Fibre Channel Adapter</Description>
+                                    <DeviceName kb="ROR" kxe="false">U78C9.001.WZS01L9-P1-C5</DeviceName>
+                                    <DynamicReconfigurationConnectorName kxe="false" kb="CUD">U78C9.001.WZS01L9-P1-C5</DynamicReconfigurationConnectorName>
+                                    <PhysicalLocation kb="ROR" kxe="false">C5</PhysicalLocation>
+                                    <UniqueDeviceID kb="ROR" kxe="false">61696</UniqueDeviceID>
+                                    <LogicalPartitionAssignmentCapable ksv="V1_2_0" kb="ROO" kxe="false">true</LogicalPartitionAssignmentCapable>
+                                    <DynamicPartitionAssignmentCapable ksv="V1_3_0" kb="ROR" kxe="false">true</DynamicPartitionAssignmentCapable>
+                                </IOAdapter>
+                            </RelatedIOAdapter>
+                            <SlotDynamicReconfigurationConnectorIndex kb="ROR" kxe="false">553713697</SlotDynamicReconfigurationConnectorIndex>
+                            <SlotDynamicReconfigurationConnectorName kxe="false" kb="CUD">U78C9.001.WZS01L9-P1-C5</SlotDynamicReconfigurationConnectorName>
+                            <SlotPhysicalLocationCode kb="ROR" kxe="false">C5</SlotPhysicalLocationCode>
+                            <SRIOVCapableDevice ksv="V1_3_0" kxe="false" kb="ROO">false</SRIOVCapableDevice>
+                            <SRIOVCapableSlot ksv="V1_3_0" kxe="false" kb="ROO">true</SRIOVCapableSlot>
+                            <SRIOVLogicalPortsLimit ksv="V1_3_0" kxe="false" kb="ROO">120</SRIOVLogicalPortsLimit>
+                        </AssociatedIOSlot>
+                    </ProfileIOSlot>
+                </ProfileIOSlots>
+                <CurrentMaximumVirtualIOSlots kxe="false" kb="ROR">10</CurrentMaximumVirtualIOSlots>
+            </PartitionIOConfiguration>
+            <PartitionMemoryConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <ActiveMemoryExpansionEnabled kb="CUD" kxe="false">false</ActiveMemoryExpansionEnabled>
+                <ActiveMemorySharingEnabled kxe="false" kb="CUD">false</ActiveMemorySharingEnabled>
+                <DesiredMemory kxe="false" kb="CUD">10240</DesiredMemory>
+                <ExpansionFactor kxe="false" kb="CUD">0.0</ExpansionFactor>
+                <HardwarePageTableRatio kb="CUD" kxe="false">7</HardwarePageTableRatio>
+                <MaximumMemory kb="CUD" kxe="false">10240</MaximumMemory>
+                <MinimumMemory kb="CUD" kxe="false">5120</MinimumMemory>
+                <CurrentExpansionFactor kb="ROR" kxe="false">0.0</CurrentExpansionFactor>
+                <CurrentHardwarePageTableRatio kb="ROR" kxe="false">7</CurrentHardwarePageTableRatio>
+                <CurrentHugePageCount kxe="false" kb="ROR">0</CurrentHugePageCount>
+                <CurrentMaximumHugePageCount kb="ROR" kxe="false">0</CurrentMaximumHugePageCount>
+                <CurrentMaximumMemory kxe="false" kb="ROR">10240</CurrentMaximumMemory>
+                <CurrentMemory kb="ROR" kxe="false">10240</CurrentMemory>
+                <CurrentMinimumHugePageCount kxe="false" kb="ROR">0</CurrentMinimumHugePageCount>
+                <CurrentMinimumMemory kxe="false" kb="ROR">5120</CurrentMinimumMemory>
+                <MemoryExpansionHardwareAccessEnabled kb="ROR" kxe="false">false</MemoryExpansionHardwareAccessEnabled>
+                <MemoryEncryptionHardwareAccessEnabled kxe="false" kb="ROR">true</MemoryEncryptionHardwareAccessEnabled>
+                <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
+                <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
+                <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
+                <RuntimeMemory kxe="false" kb="ROR">256</RuntimeMemory>
+                <RuntimeMinimumMemory kxe="false" kb="ROR">5120</RuntimeMinimumMemory>
+                <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
+            </PartitionMemoryConfiguration>
+            <PartitionName kb="CUR" kxe="false">aramis-vios2</PartitionName>
+            <PartitionProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <HasDedicatedProcessors kxe="false" kb="CUD">false</HasDedicatedProcessors>
+                <SharedProcessorConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <DesiredProcessingUnits kxe="false" kb="CUD">0.4</DesiredProcessingUnits>
+                    <DesiredVirtualProcessors kb="CUD" kxe="false">1</DesiredVirtualProcessors>
+                    <MaximumProcessingUnits kxe="false" kb="CUD">1.5</MaximumProcessingUnits>
+                    <MaximumVirtualProcessors kxe="false" kb="CUD">2</MaximumVirtualProcessors>
+                    <MinimumProcessingUnits kb="CUD" kxe="false">0.2</MinimumProcessingUnits>
+                    <MinimumVirtualProcessors kb="CUD" kxe="false">1</MinimumVirtualProcessors>
+                    <SharedProcessorPoolID kxe="false" kb="CUD">0</SharedProcessorPoolID>
+                    <UncappedWeight kb="CUD" kxe="false">128</UncappedWeight>
+                </SharedProcessorConfiguration>
+                <SharingMode kxe="false" kb="CUD">uncapped</SharingMode>
+                <CurrentHasDedicatedProcessors kb="ROR" kxe="false">false</CurrentHasDedicatedProcessors>
+                <CurrentSharingMode kb="ROR" kxe="false">uncapped</CurrentSharingMode>
+                <RuntimeHasDedicatedProcessors kxe="false" kb="ROR">false</RuntimeHasDedicatedProcessors>
+                <CurrentSharedProcessorConfiguration kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <AllocatedVirtualProcessors kxe="false" kb="ROR">1</AllocatedVirtualProcessors>
+                    <CurrentMaximumProcessingUnits kxe="false" kb="ROR">1.5</CurrentMaximumProcessingUnits>
+                    <CurrentMinimumProcessingUnits kb="ROR" kxe="false">0.2</CurrentMinimumProcessingUnits>
+                    <CurrentProcessingUnits kxe="false" kb="ROR">0.4</CurrentProcessingUnits>
+                    <CurrentSharedProcessorPoolID kxe="false" kb="ROR">0</CurrentSharedProcessorPoolID>
+                    <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
+                    <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
+                    <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">2</CurrentMaximumVirtualProcessors>
+                    <RuntimeProcessingUnits kxe="false" kb="ROR">0</RuntimeProcessingUnits>
+                    <RuntimeUncappedWeight kb="ROR" kxe="false">0</RuntimeUncappedWeight>
+                </CurrentSharedProcessorConfiguration>
+            </PartitionProcessorConfiguration>
+            <PartitionProfiles kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/LogicalPartitionProfile/ca05d361-8360-3bdc-926b-e677292e458c" rel="related"/>
+            </PartitionProfiles>
+            <PartitionState kxe="false" kb="ROO">not activated</PartitionState>
+            <PartitionType kb="COD" kxe="false">Virtual IO Server</PartitionType>
+            <PartitionUUID kxe="false" kb="ROO">785FB584-AA40-460D-8803-A38AA0271030</PartitionUUID>
+            <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
+            <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
+            <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
+            <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
+            <ResourceMonitoringIPAddress kb="CUD" kxe="false">10.197.64.116</ResourceMonitoringIPAddress>
+            <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
+            <ClientNetworkAdapters kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter/dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb" rel="related"/>
+            </ClientNetworkAdapters>
+            <HostEthernetAdapterLogicalPorts kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+            </HostEthernetAdapterLogicalPorts>
+            <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
+            <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
+            <ReferenceCode kb="ROO" kxe="true">00000000</ReferenceCode>
+            <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <APICapable kb="CUD" kxe="false">false</APICapable>
+            <IsVNICCapable ksv="V1_3_0" kxe="false" kb="CUD">false</IsVNICCapable>
+            <VNICFailOverCapable ksv="V1_4_0" kxe="false" kb="CUD">false</VNICFailOverCapable>
+            <ManagerPassthroughCapable kxe="false" kb="CUD">false</ManagerPassthroughCapable>
+            <MoverServicePartition kxe="false" kb="CUD">true</MoverServicePartition>
+            <TrunkAdapters group="ViosNetwork" kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+            </TrunkAdapters>
+            <VirtualFibreChannelMappings group="ViosFCMapping" kxe="false" kb="CUD" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+            </VirtualFibreChannelMappings>
+            <VirtualSCSIMappings group="ViosSCSIMapping" kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <VirtualSCSIMapping schemaVersion="V1_5_0">
+                    <Metadata>
+                        <Atom/>
+                    </Metadata>
+                    <AssociatedLogicalPartition kxe="false" kb="CUR" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/654DC1E7-ECD3-4424-88CF-3E23E1004257" rel="related"/>
+                    <ClientAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
+                        <Metadata>
+                            <Atom/>
+                        </Metadata>
+                        <AdapterType kb="ROR" kxe="false">Client</AdapterType>
+                        <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V4-C5</DynamicReconfigurationConnectorName>
+                        <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V4-C5</LocationCode>
+                        <LocalPartitionID kxe="false" kb="CUR">4</LocalPartitionID>
+                        <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
+                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
+                        <VirtualSlotNumber kb="COD" kxe="false">5</VirtualSlotNumber>
+                        <RemoteLogicalPartitionID kxe="false" kb="CUR">3</RemoteLogicalPartitionID>
+                        <RemoteSlotNumber kxe="false" kb="CUA">3</RemoteSlotNumber>
+                        <ServerLocationCode kb="CUR" kxe="false">U8286.42A.214D29V-V3-C3</ServerLocationCode>
+                    </ClientAdapter>
+                    <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
+                        <Metadata>
+                            <Atom/>
+                        </Metadata>
+                        <AdapterType kb="ROR" kxe="false">Server</AdapterType>
+                        <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V3-C3</DynamicReconfigurationConnectorName>
+                        <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V3-C3</LocationCode>
+                        <LocalPartitionID kxe="false" kb="CUR">3</LocalPartitionID>
+                        <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
+                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
+                        <VirtualSlotNumber kb="COD" kxe="false">3</VirtualSlotNumber>
+                        <RemoteLogicalPartitionID kxe="false" kb="CUR">4</RemoteLogicalPartitionID>
+                        <RemoteSlotNumber kxe="false" kb="CUA">5</RemoteSlotNumber>
+                        <ServerLocationCode kb="CUR" kxe="false">U8286.42A.214D29V-V4-C5</ServerLocationCode>
+                    </ServerAdapter>
+                </VirtualSCSIMapping>
+            </VirtualSCSIMappings>
+            <VirtualNICBackingDevices group="VNIC" ksv="V1_3_0" kb="ROR" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+            </VirtualNICBackingDevices>
+        </VirtualIOServer:VirtualIOServer>
+                </content>
+            </entry>
+            <entry>
                 <id>4494A109-8B0F-4923-8BCB-71CE8D9E5D18</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:48.824+01:00</published>
+                <published>2022-11-17T09:39:47.679+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/4494A109-8B0F-4923-8BCB-71CE8D9E5D18?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -28575,7 +28686,7 @@ http_interactions:
             <entry>
                 <id>4165A16F-0766-40F3-B9E2-7272E1910F2E</id>
                 <title>VirtualIOServer</title>
-                <published>2022-11-16T11:48:48.840+01:00</published>
+                <published>2022-11-17T09:39:47.695+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -30552,7 +30663,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:34 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:31 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/12F4DFC3-8D5E-42B2-B34A-E1D4EF55FE0A/ClientNetworkAdapter
@@ -30592,14 +30703,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>dc7538fb-d961-33b6-9bca-f07db3dbb8f2</id>
-            <updated>2022-11-16T11:48:49.337+01:00</updated>
+            <updated>2022-11-17T09:39:48.194+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/12F4DFC3-8D5E-42B2-B34A-E1D4EF55FE0A/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>ce17e8e5-5d8f-36cc-b47c-b70bade83329</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:49.351+01:00</published>
+                <published>2022-11-17T09:39:48.209+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/12F4DFC3-8D5E-42B2-B34A-E1D4EF55FE0A/ClientNetworkAdapter/ce17e8e5-5d8f-36cc-b47c-b70bade83329"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -30636,7 +30747,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:34 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371/ClientNetworkAdapter
@@ -30676,14 +30787,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>a50051d6-b0fd-375c-80a7-6f2f5775ae21</id>
-            <updated>2022-11-16T11:48:49.399+01:00</updated>
+            <updated>2022-11-17T09:39:48.275+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>19bc1fc3-c8c2-358d-b45f-79c31dfaae6c</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:49.414+01:00</published>
+                <published>2022-11-17T09:39:48.291+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371/ClientNetworkAdapter/19bc1fc3-c8c2-358d-b45f-79c31dfaae6c"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -30720,7 +30831,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:34 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/287ED600-69A9-407A-B2CF-86057C0F7A68/ClientNetworkAdapter
@@ -30760,14 +30871,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>0dfc6069-c1f7-3bb2-abbc-7a19838826c4</id>
-            <updated>2022-11-16T11:48:49.462+01:00</updated>
+            <updated>2022-11-17T09:39:48.338+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/287ED600-69A9-407A-B2CF-86057C0F7A68/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>8cfa9a9e-ce7a-3789-8769-d545409a476a</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:49.478+01:00</published>
+                <published>2022-11-17T09:39:48.354+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/287ED600-69A9-407A-B2CF-86057C0F7A68/ClientNetworkAdapter/8cfa9a9e-ce7a-3789-8769-d545409a476a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -30804,91 +30915,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:34 GMT
-- request:
-    method: get
-    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session: xxx
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Powered-By:
-      - Servlet/3.0
-      Content-Type:
-      - application/atom+xml
-      Etag:
-      - '1243183660'
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      X-Hmc-Schema-Version:
-      - V1_5_0
-      Content-Length:
-      - '3284'
-      Cache-Control:
-      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
-    body:
-      encoding: UTF-8
-      string: |2
-
-        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>213ea578-1bc8-3a21-8fac-6dddbf1d2959</id>
-            <updated>2022-11-16T11:48:49.566+01:00</updated>
-            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter"/>
-            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
-            <generator>IBM Power Systems Management Console</generator>
-            <entry>
-                <id>dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb</id>
-                <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:49.581+01:00</published>
-                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter/dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb"/>
-                <author>
-                    <name>IBM Power Systems Management Console</name>
-                </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1243183629</etag:etag>
-                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
-                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
-            <Metadata>
-                <Atom>
-                    <AtomID>dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb</AtomID>
-                    <AtomCreated>1668431890902</AtomCreated>
-                </Atom>
-            </Metadata>
-            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V3-C2</DynamicReconfigurationConnectorName>
-            <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V3-C2</LocationCode>
-            <LocalPartitionID kxe="false" kb="CUR">3</LocalPartitionID>
-            <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">false</VariedOn>
-            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
-            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
-            <MACAddress kxe="false" kb="CUR">22ED8545D502</MACAddress>
-            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
-            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">false</QualityOfServicePriorityEnabled>
-            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
-            <AssociatedVirtualSwitch kxe="false" kb="CUD">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48" rel="related"/>
-            </AssociatedVirtualSwitch>
-            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
-            <VirtualNetworks kxe="false" kb="CUR">
-                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8" rel="related"/>
-            </VirtualNetworks>
-        </ClientNetworkAdapter:ClientNetworkAdapter>
-                </content>
-            </entry>
-        </feed>
-    http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:34 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/0A0DC7D2-42B2-45BD-B63F-22C5290A103C/ClientNetworkAdapter
@@ -30928,14 +30955,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>a86ae11c-f3aa-39a5-9b02-8a8bf0d6a54c</id>
-            <updated>2022-11-16T11:48:49.625+01:00</updated>
+            <updated>2022-11-17T09:39:48.405+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/0A0DC7D2-42B2-45BD-B63F-22C5290A103C/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>9b8ca851-2191-30c9-80c0-9de11294b863</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:49.640+01:00</published>
+                <published>2022-11-17T09:39:48.420+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/0A0DC7D2-42B2-45BD-B63F-22C5290A103C/ClientNetworkAdapter/9b8ca851-2191-30c9-80c0-9de11294b863"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -30972,7 +30999,91 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:34 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - '1243183660'
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '3284'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>213ea578-1bc8-3a21-8fac-6dddbf1d2959</id>
+            <updated>2022-11-17T09:39:48.470+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb</id>
+                <title>ClientNetworkAdapter</title>
+                <published>2022-11-17T09:39:48.486+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/785FB584-AA40-460D-8803-A38AA0271030/ClientNetworkAdapter/dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1243183629</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=ClientNetworkAdapter">
+                    <ClientNetworkAdapter:ClientNetworkAdapter xmlns:ClientNetworkAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>dc23b5d1-d4ee-3075-bfd0-7ceb8f3cc1bb</AtomID>
+                    <AtomCreated>1668431890902</AtomCreated>
+                </Atom>
+            </Metadata>
+            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V3-C2</DynamicReconfigurationConnectorName>
+            <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V3-C2</LocationCode>
+            <LocalPartitionID kxe="false" kb="CUR">3</LocalPartitionID>
+            <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
+            <VariedOn kxe="true" kb="CUD">false</VariedOn>
+            <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
+            <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
+            <MACAddress kxe="false" kb="CUR">22ED8545D502</MACAddress>
+            <PortVLANID kb="CUR" kxe="false">1</PortVLANID>
+            <QualityOfServicePriorityEnabled kb="CUD" kxe="false">false</QualityOfServicePriorityEnabled>
+            <TaggedVLANSupported kxe="false" kb="CUA">false</TaggedVLANSupported>
+            <AssociatedVirtualSwitch kxe="false" kb="CUD">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/f1e69d99-e617-3c5a-acd6-8b2f1b72ff48" rel="related"/>
+            </AssociatedVirtualSwitch>
+            <VirtualSwitchID kb="ROR" kxe="false">0</VirtualSwitchID>
+            <VirtualNetworks kxe="false" kb="CUR">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/ca198d5b-59da-3103-8f49-8052e45ce3b8" rel="related"/>
+            </VirtualNetworks>
+        </ClientNetworkAdapter:ClientNetworkAdapter>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/4494A109-8B0F-4923-8BCB-71CE8D9E5D18/ClientNetworkAdapter
@@ -31012,14 +31123,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>1d69defe-b6d5-3a37-bd2d-b171bebdc03d</id>
-            <updated>2022-11-16T11:48:49.683+01:00</updated>
+            <updated>2022-11-17T09:39:48.537+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/4494A109-8B0F-4923-8BCB-71CE8D9E5D18/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>c0349b00-522f-3b8b-8dd0-a94ae34e7d56</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-11-16T11:48:49.698+01:00</published>
+                <published>2022-11-17T09:39:48.552+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/4494A109-8B0F-4923-8BCB-71CE8D9E5D18/ClientNetworkAdapter/c0349b00-522f-3b8b-8dd0-a94ae34e7d56"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31056,7 +31167,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:35 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/SRIOVEthernetLogicalPort
@@ -31096,14 +31207,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>e960cc5c-502e-3273-aad7-5ab6a5e963a1</id>
-            <updated>2022-11-16T11:48:49.748+01:00</updated>
+            <updated>2022-11-17T09:39:48.605+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/SRIOVEthernetLogicalPort"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>1f810d37-3a8d-3a48-a70a-a31e3bfd76cd</id>
                 <title>SRIOVEthernetLogicalPort</title>
-                <published>2022-11-16T11:48:49.761+01:00</published>
+                <published>2022-11-17T09:39:48.618+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/SRIOVEthernetLogicalPort/1f810d37-3a8d-3a48-a70a-a31e3bfd76cd"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31143,7 +31254,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:35 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE/SRIOVEthernetLogicalPort
@@ -31183,14 +31294,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>f5bce9ad-c183-3f7a-943d-f040b532ec04</id>
-            <updated>2022-11-16T11:48:49.834+01:00</updated>
+            <updated>2022-11-17T09:39:48.705+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE/SRIOVEthernetLogicalPort"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>6f6698c3-6d70-320e-9a2b-3ed7e757c35f</id>
                 <title>SRIOVEthernetLogicalPort</title>
-                <published>2022-11-16T11:48:49.860+01:00</published>
+                <published>2022-11-17T09:39:48.730+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE/SRIOVEthernetLogicalPort/6f6698c3-6d70-320e-9a2b-3ed7e757c35f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31231,7 +31342,7 @@ http_interactions:
             <entry>
                 <id>42847b94-42a9-39f3-93ad-35f51de01e7c</id>
                 <title>SRIOVEthernetLogicalPort</title>
-                <published>2022-11-16T11:48:49.861+01:00</published>
+                <published>2022-11-17T09:39:48.731+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE/SRIOVEthernetLogicalPort/42847b94-42a9-39f3-93ad-35f51de01e7c"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31275,7 +31386,7 @@ http_interactions:
             <entry>
                 <id>ebb26a2a-c894-361e-9499-6b42eb9d0237</id>
                 <title>SRIOVEthernetLogicalPort</title>
-                <published>2022-11-16T11:48:49.862+01:00</published>
+                <published>2022-11-17T09:39:48.732+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE/SRIOVEthernetLogicalPort/ebb26a2a-c894-361e-9499-6b42eb9d0237"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31318,7 +31429,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:35 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:32 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/VirtualNICDedicated
@@ -31358,14 +31469,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>be0f88a8-d471-3d9b-8ddc-a3190e5c85b2</id>
-            <updated>2022-11-16T11:48:51.040+01:00</updated>
+            <updated>2022-11-17T09:39:49.900+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/VirtualNICDedicated"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>da4a7764-a2d6-395d-b860-d44ef4cb5b83</id>
                 <title>VirtualNICDedicated</title>
-                <published>2022-11-16T11:48:51.233+01:00</published>
+                <published>2022-11-17T09:39:50.076+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/VirtualNICDedicated/da4a7764-a2d6-395d-b860-d44ef4cb5b83"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31423,7 +31534,7 @@ http_interactions:
             <entry>
                 <id>2fe95156-24a2-321a-8cef-0fc4854812d0</id>
                 <title>VirtualNICDedicated</title>
-                <published>2022-11-16T11:48:51.234+01:00</published>
+                <published>2022-11-17T09:39:50.077+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/6B81F3E1-C323-497D-9F91-BA52D09AF91C/VirtualNICDedicated/2fe95156-24a2-321a-8cef-0fc4854812d0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -31480,7 +31591,116 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:36 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:34 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/Group
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - "-1146424212"
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '4659'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>3d9231ee-e5bc-38e7-b59c-00f9a1384022</id>
+            <updated>2022-11-17T09:39:50.196+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>24f0e0fe-7879-4050-be45-a6e76426423d</id>
+                <title>Group</title>
+                <published>2022-11-17T09:39:50.198+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group/24f0e0fe-7879-4050-be45-a6e76426423d"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1676141590</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=Group">
+                    <Group:Group xmlns:Group="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_2_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>24f0e0fe-7879-4050-be45-a6e76426423d</AtomID>
+                    <AtomCreated>1668674390197</AtomCreated>
+                </Atom>
+            </Metadata>
+            <GroupUUID ksv="V1_2_0" kb="ROR" kxe="false">24f0e0fe-7879-4050-be45-a6e76426423d</GroupUUID>
+            <GroupName ksv="V1_2_0" kb="COR" kxe="false">mon_groupe</GroupName>
+            <GroupDescription ksv="V1_2_0" kxe="false" kb="COR"/>
+            <GroupColor ksv="V1_2_0" kb="COR" kxe="false">Grey</GroupColor>
+            <AssociatedLogicalPartitions ksv="V1_2_0" kb="COD" kxe="false">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/00000000-0000-0000-0000-000000000000" rel="related"/>
+            </AssociatedLogicalPartitions>
+            <AssociatedVirtualIOServers ksv="V1_2_0" kxe="false" kb="COD">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371" rel="related"/>
+            </AssociatedVirtualIOServers>
+            <AssociatedManagedSystems ksv="V1_2_0" kb="COD" kxe="false"/>
+        </Group:Group>
+                </content>
+            </entry>
+            <entry>
+                <id>73254f6f-5977-4642-92cd-3cdc8a0632a0</id>
+                <title>Group</title>
+                <published>2022-11-17T09:39:50.199+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group/73254f6f-5977-4642-92cd-3cdc8a0632a0"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-725643435</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=Group">
+                    <Group:Group xmlns:Group="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_2_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>73254f6f-5977-4642-92cd-3cdc8a0632a0</AtomID>
+                    <AtomCreated>1668674390197</AtomCreated>
+                </Atom>
+            </Metadata>
+            <GroupUUID ksv="V1_2_0" kb="ROR" kxe="false">73254f6f-5977-4642-92cd-3cdc8a0632a0</GroupUUID>
+            <GroupName ksv="V1_2_0" kb="COR" kxe="false">ManageIQ</GroupName>
+            <GroupDescription ksv="V1_2_0" kxe="false" kb="COR"/>
+            <GroupColor ksv="V1_2_0" kb="COR" kxe="false">Orange</GroupColor>
+            <AssociatedLogicalPartitions ksv="V1_2_0" kb="COD" kxe="false">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3" rel="related"/>
+            </AssociatedLogicalPartitions>
+            <AssociatedVirtualIOServers ksv="V1_2_0" kxe="false" kb="COD">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E" rel="related"/>
+            </AssociatedVirtualIOServers>
+            <AssociatedManagedSystems ksv="V1_2_0" kb="COD" kxe="false"/>
+        </Group:Group>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:08:34 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/templates/PartitionTemplate?detail=full&draft=false
@@ -31515,12 +31735,12 @@ http_interactions:
       string: |2
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <updated>2022-11-16T11:48:51.987+01:00</updated>
+            <updated>2022-11-17T09:39:50.879+01:00</updated>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>b39f29e7-d5ca-4f02-9f7a-92bf18370f8d</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.965+01:00</published>
+                <published>2022-11-17T09:39:50.858+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -31910,7 +32130,7 @@ http_interactions:
             <entry>
                 <id>892e6d2b-2677-4f21-a555-55efa2fe6548</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.966+01:00</published>
+                <published>2022-11-17T09:39:50.858+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -32037,7 +32257,7 @@ http_interactions:
             <entry>
                 <id>3f109ae5-8553-4545-b211-c0de284c4872</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.967+01:00</published>
+                <published>2022-11-17T09:39:50.859+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -32236,7 +32456,7 @@ http_interactions:
             <entry>
                 <id>f03c8027-aba2-461e-a367-3a8f3df2569d</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.969+01:00</published>
+                <published>2022-11-17T09:39:50.861+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -32626,7 +32846,7 @@ http_interactions:
             <entry>
                 <id>609f6396-e3be-48f5-83fb-d793cbc16183</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.970+01:00</published>
+                <published>2022-11-17T09:39:50.862+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -32753,7 +32973,7 @@ http_interactions:
             <entry>
                 <id>d89a0d5b-756c-49f8-864e-9710d1f16451</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.972+01:00</published>
+                <published>2022-11-17T09:39:50.864+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -33122,7 +33342,7 @@ http_interactions:
             <entry>
                 <id>72c6dc00-ff9f-4927-ab1d-853fc9891fda</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.973+01:00</published>
+                <published>2022-11-17T09:39:50.865+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -33248,7 +33468,7 @@ http_interactions:
             <entry>
                 <id>51e03ded-1008-4aff-9eac-aab04044935a</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.974+01:00</published>
+                <published>2022-11-17T09:39:50.867+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -33617,7 +33837,7 @@ http_interactions:
             <entry>
                 <id>5650910e-1529-4594-be62-827f28d5f6e6</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.976+01:00</published>
+                <published>2022-11-17T09:39:50.868+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -33986,7 +34206,7 @@ http_interactions:
             <entry>
                 <id>67436585-b854-4c2e-91e9-e17fcbf751bf</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.977+01:00</published>
+                <published>2022-11-17T09:39:50.869+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -34157,7 +34377,7 @@ http_interactions:
             <entry>
                 <id>2216fa0f-7505-403e-b00f-36e51e8d979d</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.978+01:00</published>
+                <published>2022-11-17T09:39:50.870+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -34284,7 +34504,7 @@ http_interactions:
             <entry>
                 <id>a556fe16-a02c-472b-87a0-283483f5d883</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.979+01:00</published>
+                <published>2022-11-17T09:39:50.871+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -34411,7 +34631,7 @@ http_interactions:
             <entry>
                 <id>44fb575e-2733-4ce5-b30a-cce40378f836</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.980+01:00</published>
+                <published>2022-11-17T09:39:50.872+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -34565,7 +34785,7 @@ http_interactions:
             <entry>
                 <id>3343a886-46e8-4363-8d7e-5f0a319fdcba</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.981+01:00</published>
+                <published>2022-11-17T09:39:50.873+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -34757,7 +34977,7 @@ http_interactions:
             <entry>
                 <id>bd162edc-4e1f-4f20-8833-463b53cb7517</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.982+01:00</published>
+                <published>2022-11-17T09:39:50.874+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -34884,7 +35104,7 @@ http_interactions:
             <entry>
                 <id>e05185be-a7de-4b88-bae4-e3823867f1f1</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.983+01:00</published>
+                <published>2022-11-17T09:39:50.875+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -35253,7 +35473,7 @@ http_interactions:
             <entry>
                 <id>23e72d33-cbd3-4b73-ae4f-420c86166622</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.984+01:00</published>
+                <published>2022-11-17T09:39:50.876+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -35424,7 +35644,7 @@ http_interactions:
             <entry>
                 <id>84f2d0b8-d86e-4a51-a012-8ddc4339c1f7</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.985+01:00</published>
+                <published>2022-11-17T09:39:50.878+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -35623,7 +35843,7 @@ http_interactions:
             <entry>
                 <id>ac3bcd1a-b721-425b-9202-75a0b9d48925</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.986+01:00</published>
+                <published>2022-11-17T09:39:50.878+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -35749,7 +35969,7 @@ http_interactions:
             <entry>
                 <id>3f4458d0-d51e-4d80-aa03-8edeaa529db7</id>
                 <title>PartitionTemplate</title>
-                <published>2022-11-16T11:48:51.987+01:00</published>
+                <published>2022-11-17T09:39:50.879+01:00</published>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
@@ -35875,7 +36095,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:37 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:35 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/SharedStoragePool?ignoreError=true
@@ -35915,14 +36135,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>1ada30ef-2ea7-3396-953b-27b3081d8c39</id>
-            <updated>2022-11-16T11:48:52.900+01:00</updated>
+            <updated>2022-11-17T09:39:51.620+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/SharedStoragePool?ignoreError=true"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>4afae2fc-e45f-3e05-a0e2-9aeecde3c122</id>
                 <title>SharedStoragePool</title>
-                <published>2022-11-16T11:48:53.353+01:00</published>
+                <published>2022-11-17T09:39:52.163+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/SharedStoragePool/4afae2fc-e45f-3e05-a0e2-9aeecde3c122?ignoreError=true"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36020,7 +36240,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:38 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:36 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool
@@ -36045,7 +36265,7 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-102734915"
+      - '1951417625'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
@@ -36060,19 +36280,19 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>0b300841-03bc-366f-9656-6750e62a773e</id>
-            <updated>2022-11-16T11:48:53.460+01:00</updated>
+            <updated>2022-11-17T09:39:52.214+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>74e47b2e-b370-3cf1-a274-47ee7a6550e7</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.499+01:00</published>
+                <published>2022-11-17T09:39:52.347+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/74e47b2e-b370-3cf1-a274-47ee7a6550e7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1721253966</etag:etag>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">777464278</etag:etag>
                 <content type="application/vnd.ibm.powervm.uom+xml; type=SharedProcessorPool">
                     <SharedProcessorPool:SharedProcessorPool xmlns:SharedProcessorPool="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
@@ -36089,6 +36309,7 @@ http_interactions:
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/3F3D399B-DFF3-4977-8881-C194AA47CD3A" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/0D323064-36E2-455A-AB06-46BD079AD545" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04" rel="related"/>
             </AssignedPartitions>
             <PoolID kb="ROR" kxe="false">0</PoolID>
             <AvailableProcUnits kxe="false" kb="CUD">0</AvailableProcUnits>
@@ -36099,7 +36320,7 @@ http_interactions:
             <entry>
                 <id>d4d68a99-390f-325a-8336-d07802c9463b</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.499+01:00</published>
+                <published>2022-11-17T09:39:52.350+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/d4d68a99-390f-325a-8336-d07802c9463b"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36125,7 +36346,7 @@ http_interactions:
             <entry>
                 <id>c41d8844-1d39-3512-944d-50f58de2d42d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.500+01:00</published>
+                <published>2022-11-17T09:39:52.350+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/c41d8844-1d39-3512-944d-50f58de2d42d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36151,7 +36372,7 @@ http_interactions:
             <entry>
                 <id>f889d533-f16d-30d5-81d2-e4dc7bc8d69a</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.501+01:00</published>
+                <published>2022-11-17T09:39:52.353+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/f889d533-f16d-30d5-81d2-e4dc7bc8d69a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36180,7 +36401,7 @@ http_interactions:
             <entry>
                 <id>493bfad0-19ad-3ae9-bffc-4d1377479cd6</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.501+01:00</published>
+                <published>2022-11-17T09:39:52.355+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/493bfad0-19ad-3ae9-bffc-4d1377479cd6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36206,7 +36427,7 @@ http_interactions:
             <entry>
                 <id>61d24fec-fea7-368b-94f5-e17995092971</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.502+01:00</published>
+                <published>2022-11-17T09:39:52.358+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/61d24fec-fea7-368b-94f5-e17995092971"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36232,7 +36453,7 @@ http_interactions:
             <entry>
                 <id>9598135b-77b6-3c66-b745-1e54a14c5fca</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.503+01:00</published>
+                <published>2022-11-17T09:39:52.360+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/9598135b-77b6-3c66-b745-1e54a14c5fca"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36258,7 +36479,7 @@ http_interactions:
             <entry>
                 <id>316e7473-7dd5-3b3f-b595-5508c84b604f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.503+01:00</published>
+                <published>2022-11-17T09:39:52.361+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/316e7473-7dd5-3b3f-b595-5508c84b604f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36284,7 +36505,7 @@ http_interactions:
             <entry>
                 <id>0210375c-cc56-34c6-8336-8a95bcc1e3c2</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.504+01:00</published>
+                <published>2022-11-17T09:39:52.363+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/0210375c-cc56-34c6-8336-8a95bcc1e3c2"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36310,7 +36531,7 @@ http_interactions:
             <entry>
                 <id>3bba035a-1470-31cb-aa27-94d980005b06</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.505+01:00</published>
+                <published>2022-11-17T09:39:52.365+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/3bba035a-1470-31cb-aa27-94d980005b06"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36336,7 +36557,7 @@ http_interactions:
             <entry>
                 <id>15664b9e-b362-3bd8-93e1-943cfbefdaca</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.506+01:00</published>
+                <published>2022-11-17T09:39:52.368+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/15664b9e-b362-3bd8-93e1-943cfbefdaca"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36362,7 +36583,7 @@ http_interactions:
             <entry>
                 <id>77c8bad4-89d3-3f83-9270-99eea46a8ced</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.506+01:00</published>
+                <published>2022-11-17T09:39:52.369+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/77c8bad4-89d3-3f83-9270-99eea46a8ced"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36388,7 +36609,7 @@ http_interactions:
             <entry>
                 <id>2af9e0c9-38bd-3cc9-8139-70270d9c0b7d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.507+01:00</published>
+                <published>2022-11-17T09:39:52.371+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/2af9e0c9-38bd-3cc9-8139-70270d9c0b7d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36414,7 +36635,7 @@ http_interactions:
             <entry>
                 <id>14e58740-f106-37d9-b714-e18b7c5ad285</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.508+01:00</published>
+                <published>2022-11-17T09:39:52.373+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/14e58740-f106-37d9-b714-e18b7c5ad285"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36440,7 +36661,7 @@ http_interactions:
             <entry>
                 <id>3dc50881-6052-3bf0-a429-99abe2af8a70</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.508+01:00</published>
+                <published>2022-11-17T09:39:52.375+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/3dc50881-6052-3bf0-a429-99abe2af8a70"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36466,7 +36687,7 @@ http_interactions:
             <entry>
                 <id>27aae064-2855-39a0-b4e6-e3c9b5572036</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.509+01:00</published>
+                <published>2022-11-17T09:39:52.378+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/27aae064-2855-39a0-b4e6-e3c9b5572036"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36492,7 +36713,7 @@ http_interactions:
             <entry>
                 <id>2835674a-7db1-362f-b1ca-4596c71266b5</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.510+01:00</published>
+                <published>2022-11-17T09:39:52.378+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/2835674a-7db1-362f-b1ca-4596c71266b5"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36518,7 +36739,7 @@ http_interactions:
             <entry>
                 <id>611ce3f0-c1e7-3b37-8e0d-dcf8a7053dd0</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.510+01:00</published>
+                <published>2022-11-17T09:39:52.381+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/611ce3f0-c1e7-3b37-8e0d-dcf8a7053dd0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36544,7 +36765,7 @@ http_interactions:
             <entry>
                 <id>ec37df87-65a8-3f17-ad7b-a91c0d09a1a7</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.511+01:00</published>
+                <published>2022-11-17T09:39:52.383+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/ec37df87-65a8-3f17-ad7b-a91c0d09a1a7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36570,7 +36791,7 @@ http_interactions:
             <entry>
                 <id>c3e8f664-dd85-3d88-b01c-3fc1ed813232</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.512+01:00</published>
+                <published>2022-11-17T09:39:52.385+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/c3e8f664-dd85-3d88-b01c-3fc1ed813232"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36596,7 +36817,7 @@ http_interactions:
             <entry>
                 <id>b6cfd450-9f2f-399b-9a1f-d2bfff1d7165</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.512+01:00</published>
+                <published>2022-11-17T09:39:52.387+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/b6cfd450-9f2f-399b-9a1f-d2bfff1d7165"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36622,7 +36843,7 @@ http_interactions:
             <entry>
                 <id>ce2c9628-7747-32b5-bee9-587d39d7b793</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.513+01:00</published>
+                <published>2022-11-17T09:39:52.388+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/ce2c9628-7747-32b5-bee9-587d39d7b793"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36648,7 +36869,7 @@ http_interactions:
             <entry>
                 <id>917f7240-0e56-3af5-b8b9-f85e4208073a</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.514+01:00</published>
+                <published>2022-11-17T09:39:52.390+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/917f7240-0e56-3af5-b8b9-f85e4208073a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36674,7 +36895,7 @@ http_interactions:
             <entry>
                 <id>972ef431-8561-378d-9564-7f7f22f6152b</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.514+01:00</published>
+                <published>2022-11-17T09:39:52.393+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/972ef431-8561-378d-9564-7f7f22f6152b"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36700,7 +36921,7 @@ http_interactions:
             <entry>
                 <id>8cc81263-71b6-326c-8967-753ac6396874</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.515+01:00</published>
+                <published>2022-11-17T09:39:52.395+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/8cc81263-71b6-326c-8967-753ac6396874"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36726,7 +36947,7 @@ http_interactions:
             <entry>
                 <id>e8aa881c-09fc-3144-8840-c24dd2cb7db1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.516+01:00</published>
+                <published>2022-11-17T09:39:52.396+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/e8aa881c-09fc-3144-8840-c24dd2cb7db1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36752,7 +36973,7 @@ http_interactions:
             <entry>
                 <id>9953a700-d0e6-36dd-a36a-a0e293e0df66</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.516+01:00</published>
+                <published>2022-11-17T09:39:52.398+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/9953a700-d0e6-36dd-a36a-a0e293e0df66"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36778,7 +36999,7 @@ http_interactions:
             <entry>
                 <id>44ee2ea3-7824-377d-bdf1-9d104dde9662</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.517+01:00</published>
+                <published>2022-11-17T09:39:52.400+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/44ee2ea3-7824-377d-bdf1-9d104dde9662"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36804,7 +37025,7 @@ http_interactions:
             <entry>
                 <id>3fedb102-9e04-3169-8cc3-a47ad9fa1047</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.518+01:00</published>
+                <published>2022-11-17T09:39:52.402+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/3fedb102-9e04-3169-8cc3-a47ad9fa1047"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36830,7 +37051,7 @@ http_interactions:
             <entry>
                 <id>0191a887-c4d4-3b46-9d2c-74ed651b8e02</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.518+01:00</published>
+                <published>2022-11-17T09:39:52.404+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/0191a887-c4d4-3b46-9d2c-74ed651b8e02"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36856,7 +37077,7 @@ http_interactions:
             <entry>
                 <id>284d1bd1-5f11-392f-98d1-535c00a93fb1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.519+01:00</published>
+                <published>2022-11-17T09:39:52.405+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/284d1bd1-5f11-392f-98d1-535c00a93fb1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36882,7 +37103,7 @@ http_interactions:
             <entry>
                 <id>701f6f49-6d84-3b04-b601-bbd9fb5b4948</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.520+01:00</published>
+                <published>2022-11-17T09:39:52.407+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/701f6f49-6d84-3b04-b601-bbd9fb5b4948"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36908,7 +37129,7 @@ http_interactions:
             <entry>
                 <id>66955a0a-5ae5-3ab2-8e17-b9045b3d89a9</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.520+01:00</published>
+                <published>2022-11-17T09:39:52.409+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/66955a0a-5ae5-3ab2-8e17-b9045b3d89a9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36934,7 +37155,7 @@ http_interactions:
             <entry>
                 <id>711b0a5d-1081-3abd-a04a-b90813684f38</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.521+01:00</published>
+                <published>2022-11-17T09:39:52.411+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/711b0a5d-1081-3abd-a04a-b90813684f38"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36960,7 +37181,7 @@ http_interactions:
             <entry>
                 <id>a9c13c41-cb0a-3cf1-bec6-6db417170da4</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.522+01:00</published>
+                <published>2022-11-17T09:39:52.413+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/a9c13c41-cb0a-3cf1-bec6-6db417170da4"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -36986,7 +37207,7 @@ http_interactions:
             <entry>
                 <id>c678abf4-3304-3cca-9bc0-42b010d110c2</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.522+01:00</published>
+                <published>2022-11-17T09:39:52.413+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/c678abf4-3304-3cca-9bc0-42b010d110c2"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37012,7 +37233,7 @@ http_interactions:
             <entry>
                 <id>0e7434fe-e240-39e8-8e31-a2aa7f4f7d00</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.523+01:00</published>
+                <published>2022-11-17T09:39:52.415+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/0e7434fe-e240-39e8-8e31-a2aa7f4f7d00"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37038,7 +37259,7 @@ http_interactions:
             <entry>
                 <id>4ce4adff-4d6f-3399-b557-a49671892ba4</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.524+01:00</published>
+                <published>2022-11-17T09:39:52.417+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/4ce4adff-4d6f-3399-b557-a49671892ba4"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37064,7 +37285,7 @@ http_interactions:
             <entry>
                 <id>8e840c92-ce92-37db-bb13-50748acfff5d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.524+01:00</published>
+                <published>2022-11-17T09:39:52.419+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/8e840c92-ce92-37db-bb13-50748acfff5d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37090,7 +37311,7 @@ http_interactions:
             <entry>
                 <id>a766fac5-9eb9-3d99-a0d7-bc77be43c77e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.525+01:00</published>
+                <published>2022-11-17T09:39:52.420+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/a766fac5-9eb9-3d99-a0d7-bc77be43c77e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37116,7 +37337,7 @@ http_interactions:
             <entry>
                 <id>a5f0a4fe-eba5-3b3e-81df-b2c1f1e9c54d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.526+01:00</published>
+                <published>2022-11-17T09:39:52.422+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/a5f0a4fe-eba5-3b3e-81df-b2c1f1e9c54d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37142,7 +37363,7 @@ http_interactions:
             <entry>
                 <id>3a3c98ae-2490-3eab-b330-4291f7b25126</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.526+01:00</published>
+                <published>2022-11-17T09:39:52.424+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/3a3c98ae-2490-3eab-b330-4291f7b25126"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37168,7 +37389,7 @@ http_interactions:
             <entry>
                 <id>84f2cedd-1f43-3b90-bf61-c8a5a6718fcb</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.527+01:00</published>
+                <published>2022-11-17T09:39:52.426+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/84f2cedd-1f43-3b90-bf61-c8a5a6718fcb"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37194,7 +37415,7 @@ http_interactions:
             <entry>
                 <id>e928b915-be66-3835-8771-0d60511a92a7</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.528+01:00</published>
+                <published>2022-11-17T09:39:52.428+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/e928b915-be66-3835-8771-0d60511a92a7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37220,7 +37441,7 @@ http_interactions:
             <entry>
                 <id>6c11e332-eb37-3731-bbac-3782597911e9</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.528+01:00</published>
+                <published>2022-11-17T09:39:52.429+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/6c11e332-eb37-3731-bbac-3782597911e9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37246,7 +37467,7 @@ http_interactions:
             <entry>
                 <id>2cb8174e-5e89-381e-8b0b-4ec5c6414ba1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.529+01:00</published>
+                <published>2022-11-17T09:39:52.431+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/2cb8174e-5e89-381e-8b0b-4ec5c6414ba1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37272,7 +37493,7 @@ http_interactions:
             <entry>
                 <id>e4367d1e-0e54-3852-bb90-00780a170a46</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.530+01:00</published>
+                <published>2022-11-17T09:39:52.433+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/e4367d1e-0e54-3852-bb90-00780a170a46"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37298,7 +37519,7 @@ http_interactions:
             <entry>
                 <id>41cb6a6d-a0c0-34e1-a873-acc3c1c80b05</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.530+01:00</published>
+                <published>2022-11-17T09:39:52.435+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/41cb6a6d-a0c0-34e1-a873-acc3c1c80b05"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37324,7 +37545,7 @@ http_interactions:
             <entry>
                 <id>8a24e73d-2a62-3912-89a7-263f17e9037e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.531+01:00</published>
+                <published>2022-11-17T09:39:52.437+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/8a24e73d-2a62-3912-89a7-263f17e9037e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37350,7 +37571,7 @@ http_interactions:
             <entry>
                 <id>ea21433e-d97f-31ae-95df-2bfe97c84ae6</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.532+01:00</published>
+                <published>2022-11-17T09:39:52.438+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/ea21433e-d97f-31ae-95df-2bfe97c84ae6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37376,7 +37597,7 @@ http_interactions:
             <entry>
                 <id>cecfb796-e4cb-37fa-bd73-a1719c185a12</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.532+01:00</published>
+                <published>2022-11-17T09:39:52.440+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/cecfb796-e4cb-37fa-bd73-a1719c185a12"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37402,7 +37623,7 @@ http_interactions:
             <entry>
                 <id>a5e5423d-0935-3c07-9c15-a27c4a5011ef</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.533+01:00</published>
+                <published>2022-11-17T09:39:52.442+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/a5e5423d-0935-3c07-9c15-a27c4a5011ef"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37428,7 +37649,7 @@ http_interactions:
             <entry>
                 <id>c6ad4941-62bb-3801-bf7e-c3541bcb3f57</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.534+01:00</published>
+                <published>2022-11-17T09:39:52.444+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/c6ad4941-62bb-3801-bf7e-c3541bcb3f57"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37454,7 +37675,7 @@ http_interactions:
             <entry>
                 <id>fdf1d0da-9882-363f-9602-ac643c92465e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.534+01:00</published>
+                <published>2022-11-17T09:39:52.445+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/fdf1d0da-9882-363f-9602-ac643c92465e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37480,7 +37701,7 @@ http_interactions:
             <entry>
                 <id>d33d8f14-c08a-34d6-a702-83f31cf5a658</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.535+01:00</published>
+                <published>2022-11-17T09:39:52.447+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/d33d8f14-c08a-34d6-a702-83f31cf5a658"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37506,7 +37727,7 @@ http_interactions:
             <entry>
                 <id>384df76e-893b-3909-a6ba-a1d4b84fb4e0</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.536+01:00</published>
+                <published>2022-11-17T09:39:52.449+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/384df76e-893b-3909-a6ba-a1d4b84fb4e0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37532,7 +37753,7 @@ http_interactions:
             <entry>
                 <id>729b5bfc-7505-308f-86c8-bf5100a0e5df</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.536+01:00</published>
+                <published>2022-11-17T09:39:52.450+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/729b5bfc-7505-308f-86c8-bf5100a0e5df"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37558,7 +37779,7 @@ http_interactions:
             <entry>
                 <id>d4a6c8e0-e493-3a6d-950f-b5e01c04da27</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.537+01:00</published>
+                <published>2022-11-17T09:39:52.452+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/d4a6c8e0-e493-3a6d-950f-b5e01c04da27"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37584,7 +37805,7 @@ http_interactions:
             <entry>
                 <id>5affb903-6995-3b5a-b731-c7cf0dc94923</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.538+01:00</published>
+                <published>2022-11-17T09:39:52.453+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/5affb903-6995-3b5a-b731-c7cf0dc94923"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37610,7 +37831,7 @@ http_interactions:
             <entry>
                 <id>c11c17b8-3348-32c5-9b7b-d9b25d3aa3ab</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.538+01:00</published>
+                <published>2022-11-17T09:39:52.455+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/c11c17b8-3348-32c5-9b7b-d9b25d3aa3ab"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37636,7 +37857,7 @@ http_interactions:
             <entry>
                 <id>01ff52f3-5c48-36b1-a1d5-59422fed3966</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.539+01:00</published>
+                <published>2022-11-17T09:39:52.457+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/01ff52f3-5c48-36b1-a1d5-59422fed3966"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37662,7 +37883,7 @@ http_interactions:
             <entry>
                 <id>a7ee974f-21af-3894-a235-56d5f3ace9af</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.540+01:00</published>
+                <published>2022-11-17T09:39:52.459+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/a7ee974f-21af-3894-a235-56d5f3ace9af"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37688,7 +37909,7 @@ http_interactions:
             <entry>
                 <id>69622698-e41f-3cc1-9b78-c3e0f4f51a57</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.540+01:00</published>
+                <published>2022-11-17T09:39:52.460+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/69622698-e41f-3cc1-9b78-c3e0f4f51a57"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37714,7 +37935,7 @@ http_interactions:
             <entry>
                 <id>0fb3e59e-e8ca-3e1c-88a4-511a5fb4d245</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:53.541+01:00</published>
+                <published>2022-11-17T09:39:52.461+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/0fb3e59e-e8ca-3e1c-88a4-511a5fb4d245"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37739,7 +37960,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:38 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:36 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool
@@ -37779,14 +38000,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>8b57c1fb-78e2-39dd-b9ab-6d367f8964c4</id>
-            <updated>2022-11-16T11:48:54.109+01:00</updated>
+            <updated>2022-11-17T09:39:52.849+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>1027477e-1e3a-302e-946d-274e7349b519</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.146+01:00</published>
+                <published>2022-11-17T09:39:52.945+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/1027477e-1e3a-302e-946d-274e7349b519"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37821,7 +38042,7 @@ http_interactions:
             <entry>
                 <id>2cc54673-bc37-3dbe-9136-f1848ca08f88</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.147+01:00</published>
+                <published>2022-11-17T09:39:52.946+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/2cc54673-bc37-3dbe-9136-f1848ca08f88"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37847,7 +38068,7 @@ http_interactions:
             <entry>
                 <id>0ce1cd13-1bc7-3a57-91a4-b7292b490d00</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.148+01:00</published>
+                <published>2022-11-17T09:39:52.946+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/0ce1cd13-1bc7-3a57-91a4-b7292b490d00"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37873,7 +38094,7 @@ http_interactions:
             <entry>
                 <id>8d54599f-4ad6-3e38-ba5f-a22b3cc20b2a</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.149+01:00</published>
+                <published>2022-11-17T09:39:52.947+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/8d54599f-4ad6-3e38-ba5f-a22b3cc20b2a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37899,7 +38120,7 @@ http_interactions:
             <entry>
                 <id>6c1a71da-acf3-394d-b0d7-9c0e283d9f2c</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.149+01:00</published>
+                <published>2022-11-17T09:39:52.948+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/6c1a71da-acf3-394d-b0d7-9c0e283d9f2c"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37925,7 +38146,7 @@ http_interactions:
             <entry>
                 <id>450bc24b-cbcf-31fb-a93d-fe7cb0840450</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.150+01:00</published>
+                <published>2022-11-17T09:39:52.948+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/450bc24b-cbcf-31fb-a93d-fe7cb0840450"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37951,7 +38172,7 @@ http_interactions:
             <entry>
                 <id>77ade6bc-f93c-3a8c-9c68-7b14d4f893c4</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.151+01:00</published>
+                <published>2022-11-17T09:39:52.949+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/77ade6bc-f93c-3a8c-9c68-7b14d4f893c4"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -37977,7 +38198,7 @@ http_interactions:
             <entry>
                 <id>e53d3dfa-d343-34a4-958a-e2abc26bd991</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.151+01:00</published>
+                <published>2022-11-17T09:39:52.950+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/e53d3dfa-d343-34a4-958a-e2abc26bd991"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38003,7 +38224,7 @@ http_interactions:
             <entry>
                 <id>f7ca2423-4be8-37cd-bc04-05ac6a10e781</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.152+01:00</published>
+                <published>2022-11-17T09:39:52.950+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/f7ca2423-4be8-37cd-bc04-05ac6a10e781"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38029,7 +38250,7 @@ http_interactions:
             <entry>
                 <id>816ea91c-4c7b-3804-98f6-9022ff618eef</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.153+01:00</published>
+                <published>2022-11-17T09:39:52.951+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/816ea91c-4c7b-3804-98f6-9022ff618eef"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38055,7 +38276,7 @@ http_interactions:
             <entry>
                 <id>70cf9a38-aae6-3263-a5c9-f3381b0ad3b3</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.153+01:00</published>
+                <published>2022-11-17T09:39:52.952+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/70cf9a38-aae6-3263-a5c9-f3381b0ad3b3"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38081,7 +38302,7 @@ http_interactions:
             <entry>
                 <id>bcc92758-43a5-3ad2-b01f-12ca6fec0107</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.154+01:00</published>
+                <published>2022-11-17T09:39:52.952+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/bcc92758-43a5-3ad2-b01f-12ca6fec0107"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38107,7 +38328,7 @@ http_interactions:
             <entry>
                 <id>86d181f8-c403-3089-b1ad-7ad08c8d57c1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.155+01:00</published>
+                <published>2022-11-17T09:39:52.953+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/86d181f8-c403-3089-b1ad-7ad08c8d57c1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38133,7 +38354,7 @@ http_interactions:
             <entry>
                 <id>3b1c60a8-72c8-3568-8587-93d2f54de2e4</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.155+01:00</published>
+                <published>2022-11-17T09:39:52.954+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/3b1c60a8-72c8-3568-8587-93d2f54de2e4"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38159,7 +38380,7 @@ http_interactions:
             <entry>
                 <id>4193cf44-871f-327a-9ab3-ff2884b24636</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.156+01:00</published>
+                <published>2022-11-17T09:39:52.954+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/4193cf44-871f-327a-9ab3-ff2884b24636"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38185,7 +38406,7 @@ http_interactions:
             <entry>
                 <id>a09d5390-a337-390e-b316-d8023ee7f732</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.157+01:00</published>
+                <published>2022-11-17T09:39:52.955+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/a09d5390-a337-390e-b316-d8023ee7f732"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38211,7 +38432,7 @@ http_interactions:
             <entry>
                 <id>7aa21cf8-2d86-321c-937c-dc1cc9cdd745</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.157+01:00</published>
+                <published>2022-11-17T09:39:52.956+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/7aa21cf8-2d86-321c-937c-dc1cc9cdd745"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38237,7 +38458,7 @@ http_interactions:
             <entry>
                 <id>2f39443d-e428-357d-a84d-a2531326af67</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.158+01:00</published>
+                <published>2022-11-17T09:39:52.957+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/2f39443d-e428-357d-a84d-a2531326af67"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38263,7 +38484,7 @@ http_interactions:
             <entry>
                 <id>92679629-0ee2-333f-a569-15d705eba25c</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.159+01:00</published>
+                <published>2022-11-17T09:39:52.957+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/92679629-0ee2-333f-a569-15d705eba25c"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38289,7 +38510,7 @@ http_interactions:
             <entry>
                 <id>355f85b1-0e78-36f0-8218-7ca7c9acd5fe</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.159+01:00</published>
+                <published>2022-11-17T09:39:52.958+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/355f85b1-0e78-36f0-8218-7ca7c9acd5fe"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38315,7 +38536,7 @@ http_interactions:
             <entry>
                 <id>dbc35df9-1131-367c-abad-8060987f67e9</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.160+01:00</published>
+                <published>2022-11-17T09:39:52.959+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/dbc35df9-1131-367c-abad-8060987f67e9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38341,7 +38562,7 @@ http_interactions:
             <entry>
                 <id>8fdd4bc0-26cb-366a-beb3-cfee3bb361f7</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.161+01:00</published>
+                <published>2022-11-17T09:39:52.959+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/8fdd4bc0-26cb-366a-beb3-cfee3bb361f7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38367,7 +38588,7 @@ http_interactions:
             <entry>
                 <id>1d9c9f1e-7e95-376b-9763-02580686ea2d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.161+01:00</published>
+                <published>2022-11-17T09:39:52.960+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/1d9c9f1e-7e95-376b-9763-02580686ea2d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38393,7 +38614,7 @@ http_interactions:
             <entry>
                 <id>fee0b1dc-3c54-3708-b182-95260927896c</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.162+01:00</published>
+                <published>2022-11-17T09:39:52.961+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/fee0b1dc-3c54-3708-b182-95260927896c"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38419,7 +38640,7 @@ http_interactions:
             <entry>
                 <id>792ce46e-22de-3a00-918b-9e99b3f57ea6</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.163+01:00</published>
+                <published>2022-11-17T09:39:52.961+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/792ce46e-22de-3a00-918b-9e99b3f57ea6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38445,7 +38666,7 @@ http_interactions:
             <entry>
                 <id>e4fb67cc-0fe4-3645-8572-d96758203f20</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.163+01:00</published>
+                <published>2022-11-17T09:39:52.962+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/e4fb67cc-0fe4-3645-8572-d96758203f20"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38471,7 +38692,7 @@ http_interactions:
             <entry>
                 <id>c3438fc9-701a-3ff0-b2ba-155041c6d029</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.164+01:00</published>
+                <published>2022-11-17T09:39:52.963+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/c3438fc9-701a-3ff0-b2ba-155041c6d029"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38497,7 +38718,7 @@ http_interactions:
             <entry>
                 <id>6a7c7482-dc6e-3527-9db0-fd54ee3813a4</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.165+01:00</published>
+                <published>2022-11-17T09:39:52.963+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/6a7c7482-dc6e-3527-9db0-fd54ee3813a4"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38523,7 +38744,7 @@ http_interactions:
             <entry>
                 <id>12c84f1a-a672-346f-abf3-c394adb371ea</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.165+01:00</published>
+                <published>2022-11-17T09:39:52.964+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/12c84f1a-a672-346f-abf3-c394adb371ea"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38549,7 +38770,7 @@ http_interactions:
             <entry>
                 <id>c84475d4-f144-38bb-b5bb-10466f8d0e55</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.166+01:00</published>
+                <published>2022-11-17T09:39:52.965+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/c84475d4-f144-38bb-b5bb-10466f8d0e55"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38575,7 +38796,7 @@ http_interactions:
             <entry>
                 <id>b5f3556d-6bf5-3302-8f47-b4bead63e07e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.167+01:00</published>
+                <published>2022-11-17T09:39:52.965+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/b5f3556d-6bf5-3302-8f47-b4bead63e07e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38601,7 +38822,7 @@ http_interactions:
             <entry>
                 <id>d1dd5c2e-454c-3123-bcb6-6fb7b5601179</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.167+01:00</published>
+                <published>2022-11-17T09:39:52.966+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/d1dd5c2e-454c-3123-bcb6-6fb7b5601179"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38627,7 +38848,7 @@ http_interactions:
             <entry>
                 <id>2abc8052-e010-3ca0-aa0f-080153dc660d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.168+01:00</published>
+                <published>2022-11-17T09:39:52.967+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/2abc8052-e010-3ca0-aa0f-080153dc660d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38653,7 +38874,7 @@ http_interactions:
             <entry>
                 <id>a76547b5-6fe8-300c-82da-549bf931295b</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.169+01:00</published>
+                <published>2022-11-17T09:39:52.967+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/a76547b5-6fe8-300c-82da-549bf931295b"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38679,7 +38900,7 @@ http_interactions:
             <entry>
                 <id>b4c26d1c-9aec-3579-ac14-853b5b6ee3f9</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.169+01:00</published>
+                <published>2022-11-17T09:39:52.968+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/b4c26d1c-9aec-3579-ac14-853b5b6ee3f9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38705,7 +38926,7 @@ http_interactions:
             <entry>
                 <id>1e5b3ca0-d689-3551-a133-9b4ef2417fe1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.170+01:00</published>
+                <published>2022-11-17T09:39:52.969+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/1e5b3ca0-d689-3551-a133-9b4ef2417fe1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38731,7 +38952,7 @@ http_interactions:
             <entry>
                 <id>b331c825-c42b-39ba-b495-5138d3cea72f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.171+01:00</published>
+                <published>2022-11-17T09:39:52.969+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/b331c825-c42b-39ba-b495-5138d3cea72f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38757,7 +38978,7 @@ http_interactions:
             <entry>
                 <id>fe29a46c-2afb-3520-9b8f-060143b6fdf1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.171+01:00</published>
+                <published>2022-11-17T09:39:52.970+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/fe29a46c-2afb-3520-9b8f-060143b6fdf1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38783,7 +39004,7 @@ http_interactions:
             <entry>
                 <id>13c6d196-a6ba-366c-b1d9-e64defc49cda</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.172+01:00</published>
+                <published>2022-11-17T09:39:52.971+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/13c6d196-a6ba-366c-b1d9-e64defc49cda"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38809,7 +39030,7 @@ http_interactions:
             <entry>
                 <id>a9051449-12fd-3c2e-9f38-2b4c99e23e84</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.173+01:00</published>
+                <published>2022-11-17T09:39:52.971+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/a9051449-12fd-3c2e-9f38-2b4c99e23e84"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38835,7 +39056,7 @@ http_interactions:
             <entry>
                 <id>c2cf49af-1704-3410-ab57-7c80a92ae3db</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.173+01:00</published>
+                <published>2022-11-17T09:39:52.972+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/c2cf49af-1704-3410-ab57-7c80a92ae3db"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38861,7 +39082,7 @@ http_interactions:
             <entry>
                 <id>44f18052-206a-3e9f-bb33-144f30842a6d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.174+01:00</published>
+                <published>2022-11-17T09:39:52.973+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/44f18052-206a-3e9f-bb33-144f30842a6d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38887,7 +39108,7 @@ http_interactions:
             <entry>
                 <id>b06bcb4e-6cc7-3559-b5ac-916ab6a8f360</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.175+01:00</published>
+                <published>2022-11-17T09:39:52.973+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/b06bcb4e-6cc7-3559-b5ac-916ab6a8f360"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38913,7 +39134,7 @@ http_interactions:
             <entry>
                 <id>d48f01cc-aefc-381d-adef-30d9e2d8cbec</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.175+01:00</published>
+                <published>2022-11-17T09:39:52.974+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/d48f01cc-aefc-381d-adef-30d9e2d8cbec"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38939,7 +39160,7 @@ http_interactions:
             <entry>
                 <id>d7a1f4e6-b034-33a1-b215-aeb920803185</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.176+01:00</published>
+                <published>2022-11-17T09:39:52.975+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/d7a1f4e6-b034-33a1-b215-aeb920803185"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38965,7 +39186,7 @@ http_interactions:
             <entry>
                 <id>0f73c2d0-35c1-3bd2-b9de-e81c7c71b4e6</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.177+01:00</published>
+                <published>2022-11-17T09:39:52.975+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/0f73c2d0-35c1-3bd2-b9de-e81c7c71b4e6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -38991,7 +39212,7 @@ http_interactions:
             <entry>
                 <id>91e49410-e7a5-3061-b515-502edf47d124</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.177+01:00</published>
+                <published>2022-11-17T09:39:52.976+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/91e49410-e7a5-3061-b515-502edf47d124"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39017,7 +39238,7 @@ http_interactions:
             <entry>
                 <id>affffb2d-4f6e-3211-8cc3-bb84b5d513aa</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.178+01:00</published>
+                <published>2022-11-17T09:39:52.977+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/affffb2d-4f6e-3211-8cc3-bb84b5d513aa"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39043,7 +39264,7 @@ http_interactions:
             <entry>
                 <id>5b6b1eff-bb44-33a9-87c3-79b292a5629e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.179+01:00</published>
+                <published>2022-11-17T09:39:52.977+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/5b6b1eff-bb44-33a9-87c3-79b292a5629e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39069,7 +39290,7 @@ http_interactions:
             <entry>
                 <id>fdca3d22-e805-3f9f-998a-6612af31033a</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.179+01:00</published>
+                <published>2022-11-17T09:39:52.978+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/fdca3d22-e805-3f9f-998a-6612af31033a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39095,7 +39316,7 @@ http_interactions:
             <entry>
                 <id>a88f1ced-b086-3316-ac62-4dac9883edf1</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.180+01:00</published>
+                <published>2022-11-17T09:39:52.979+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/a88f1ced-b086-3316-ac62-4dac9883edf1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39121,7 +39342,7 @@ http_interactions:
             <entry>
                 <id>cdb370ec-54bf-35d7-9abd-a564dd9eccd5</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.181+01:00</published>
+                <published>2022-11-17T09:39:52.979+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/cdb370ec-54bf-35d7-9abd-a564dd9eccd5"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39147,7 +39368,7 @@ http_interactions:
             <entry>
                 <id>a6fd860e-d7ce-365d-ac54-8a5559dbfdf9</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.182+01:00</published>
+                <published>2022-11-17T09:39:52.980+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/a6fd860e-d7ce-365d-ac54-8a5559dbfdf9"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39173,7 +39394,7 @@ http_interactions:
             <entry>
                 <id>bc6aff24-c447-3b61-bea9-0b56f2fb8265</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.182+01:00</published>
+                <published>2022-11-17T09:39:52.981+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/bc6aff24-c447-3b61-bea9-0b56f2fb8265"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39199,7 +39420,7 @@ http_interactions:
             <entry>
                 <id>20e0f3b1-3c44-3962-b391-5507d04ffc3f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.183+01:00</published>
+                <published>2022-11-17T09:39:52.981+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/20e0f3b1-3c44-3962-b391-5507d04ffc3f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39225,7 +39446,7 @@ http_interactions:
             <entry>
                 <id>c21126fb-1880-3612-8bab-58c46de39f50</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.184+01:00</published>
+                <published>2022-11-17T09:39:52.982+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/c21126fb-1880-3612-8bab-58c46de39f50"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39251,7 +39472,7 @@ http_interactions:
             <entry>
                 <id>636f0315-4f07-3161-b38e-759dd727fe1c</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.184+01:00</published>
+                <published>2022-11-17T09:39:52.983+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/636f0315-4f07-3161-b38e-759dd727fe1c"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39277,7 +39498,7 @@ http_interactions:
             <entry>
                 <id>1497b146-24f2-3a65-a8aa-9a8956ad80e6</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.185+01:00</published>
+                <published>2022-11-17T09:39:52.983+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/1497b146-24f2-3a65-a8aa-9a8956ad80e6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39303,7 +39524,7 @@ http_interactions:
             <entry>
                 <id>907987d8-29fb-3825-9264-e7d1cac844b0</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.186+01:00</published>
+                <published>2022-11-17T09:39:52.984+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/907987d8-29fb-3825-9264-e7d1cac844b0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39329,7 +39550,7 @@ http_interactions:
             <entry>
                 <id>00d8cb10-d8fc-3568-9e8b-20a211b6014d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.186+01:00</published>
+                <published>2022-11-17T09:39:52.985+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/00d8cb10-d8fc-3568-9e8b-20a211b6014d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39355,7 +39576,7 @@ http_interactions:
             <entry>
                 <id>b4b04ac0-a980-3f30-b877-ad5ae3ecb508</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.187+01:00</published>
+                <published>2022-11-17T09:39:52.985+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/b4b04ac0-a980-3f30-b877-ad5ae3ecb508"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39381,7 +39602,7 @@ http_interactions:
             <entry>
                 <id>db7ddb6d-50b6-3d4f-a125-ecd90a98d9ff</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.188+01:00</published>
+                <published>2022-11-17T09:39:52.986+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/db7ddb6d-50b6-3d4f-a125-ecd90a98d9ff"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39407,7 +39628,7 @@ http_interactions:
             <entry>
                 <id>1e2f59e3-19a6-3d3b-8225-6c44b808c882</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.188+01:00</published>
+                <published>2022-11-17T09:39:52.987+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/1e2f59e3-19a6-3d3b-8225-6c44b808c882"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39433,7 +39654,7 @@ http_interactions:
             <entry>
                 <id>efee040d-8cc2-38ae-801c-89e6091ef8a8</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.189+01:00</published>
+                <published>2022-11-17T09:39:52.987+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedProcessorPool/efee040d-8cc2-38ae-801c-89e6091ef8a8"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39458,7 +39679,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:39 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:37 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool
@@ -39498,14 +39719,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>b4ed0970-d585-34f5-9139-aa79a0942103</id>
-            <updated>2022-11-16T11:48:54.520+01:00</updated>
+            <updated>2022-11-17T09:39:53.381+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>945546e6-e848-3234-861c-72b861209d8f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.560+01:00</published>
+                <published>2022-11-17T09:39:53.421+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39551,7 +39772,7 @@ http_interactions:
             <entry>
                 <id>a83bd12f-4d0c-33db-bd0e-3c62202fa1ef</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.561+01:00</published>
+                <published>2022-11-17T09:39:53.421+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/a83bd12f-4d0c-33db-bd0e-3c62202fa1ef"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39577,7 +39798,7 @@ http_interactions:
             <entry>
                 <id>6f464d14-60f3-3382-afd2-bf35a8ff7995</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.561+01:00</published>
+                <published>2022-11-17T09:39:53.422+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/6f464d14-60f3-3382-afd2-bf35a8ff7995"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39603,7 +39824,7 @@ http_interactions:
             <entry>
                 <id>0ef09ab5-3306-3796-ade5-772e63c0dd15</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.562+01:00</published>
+                <published>2022-11-17T09:39:53.423+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/0ef09ab5-3306-3796-ade5-772e63c0dd15"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39629,7 +39850,7 @@ http_interactions:
             <entry>
                 <id>adcb3705-e78d-3c42-8b3c-f430f2ebb34f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.563+01:00</published>
+                <published>2022-11-17T09:39:53.423+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/adcb3705-e78d-3c42-8b3c-f430f2ebb34f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39655,7 +39876,7 @@ http_interactions:
             <entry>
                 <id>529e0bd8-e13e-3f86-bcb2-7d5783f8dee0</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.563+01:00</published>
+                <published>2022-11-17T09:39:53.424+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/529e0bd8-e13e-3f86-bcb2-7d5783f8dee0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39681,7 +39902,7 @@ http_interactions:
             <entry>
                 <id>49bf3220-d9d9-35da-81ba-11450ef0d555</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.564+01:00</published>
+                <published>2022-11-17T09:39:53.425+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/49bf3220-d9d9-35da-81ba-11450ef0d555"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39707,7 +39928,7 @@ http_interactions:
             <entry>
                 <id>effde712-870d-3ba1-835f-fd898b5f199e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.565+01:00</published>
+                <published>2022-11-17T09:39:53.426+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/effde712-870d-3ba1-835f-fd898b5f199e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39733,7 +39954,7 @@ http_interactions:
             <entry>
                 <id>6f3361f6-3c89-3572-b0de-84dab027e3ea</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.565+01:00</published>
+                <published>2022-11-17T09:39:53.426+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/6f3361f6-3c89-3572-b0de-84dab027e3ea"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39759,7 +39980,7 @@ http_interactions:
             <entry>
                 <id>6c9f24a0-902d-3588-a292-130264489fbf</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.566+01:00</published>
+                <published>2022-11-17T09:39:53.427+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/6c9f24a0-902d-3588-a292-130264489fbf"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39785,7 +40006,7 @@ http_interactions:
             <entry>
                 <id>6ffc5fba-7324-3923-bc94-af6c85be9c80</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.567+01:00</published>
+                <published>2022-11-17T09:39:53.428+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/6ffc5fba-7324-3923-bc94-af6c85be9c80"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39811,7 +40032,7 @@ http_interactions:
             <entry>
                 <id>d2aecbca-9c2c-30d2-94af-661f46743efd</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.567+01:00</published>
+                <published>2022-11-17T09:39:53.428+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/d2aecbca-9c2c-30d2-94af-661f46743efd"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39837,7 +40058,7 @@ http_interactions:
             <entry>
                 <id>fce5c4ba-0d6c-31e8-b6a4-42cf35ec5c2f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.568+01:00</published>
+                <published>2022-11-17T09:39:53.429+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/fce5c4ba-0d6c-31e8-b6a4-42cf35ec5c2f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39863,7 +40084,7 @@ http_interactions:
             <entry>
                 <id>6c12ed66-a711-3cb3-abe4-2c90f8e201f5</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.569+01:00</published>
+                <published>2022-11-17T09:39:53.430+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/6c12ed66-a711-3cb3-abe4-2c90f8e201f5"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39889,7 +40110,7 @@ http_interactions:
             <entry>
                 <id>c9e8a2d2-1ced-307d-83b1-233e95cdafd2</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.569+01:00</published>
+                <published>2022-11-17T09:39:53.430+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/c9e8a2d2-1ced-307d-83b1-233e95cdafd2"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39915,7 +40136,7 @@ http_interactions:
             <entry>
                 <id>625ceba3-49e8-3218-ac79-f85e4eaf2798</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.570+01:00</published>
+                <published>2022-11-17T09:39:53.431+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/625ceba3-49e8-3218-ac79-f85e4eaf2798"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39941,7 +40162,7 @@ http_interactions:
             <entry>
                 <id>ee96164f-ea42-36a6-a64a-473fee2262c0</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.571+01:00</published>
+                <published>2022-11-17T09:39:53.432+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/ee96164f-ea42-36a6-a64a-473fee2262c0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39967,7 +40188,7 @@ http_interactions:
             <entry>
                 <id>1be6c7ae-5bb7-3180-b836-c6c0285b73e7</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.571+01:00</published>
+                <published>2022-11-17T09:39:53.432+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/1be6c7ae-5bb7-3180-b836-c6c0285b73e7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -39993,7 +40214,7 @@ http_interactions:
             <entry>
                 <id>b18a2d97-401f-3689-a05a-4757744df482</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.572+01:00</published>
+                <published>2022-11-17T09:39:53.433+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/b18a2d97-401f-3689-a05a-4757744df482"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40019,7 +40240,7 @@ http_interactions:
             <entry>
                 <id>62038d5e-84a2-3fb1-80d1-53812b606d2d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.573+01:00</published>
+                <published>2022-11-17T09:39:53.434+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/62038d5e-84a2-3fb1-80d1-53812b606d2d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40045,7 +40266,7 @@ http_interactions:
             <entry>
                 <id>1a550b2d-ed1e-310c-b1a4-c4cf12167486</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.573+01:00</published>
+                <published>2022-11-17T09:39:53.434+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/1a550b2d-ed1e-310c-b1a4-c4cf12167486"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40071,7 +40292,7 @@ http_interactions:
             <entry>
                 <id>9da02249-b644-31c9-833d-0bd5a41213f2</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.574+01:00</published>
+                <published>2022-11-17T09:39:53.435+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/9da02249-b644-31c9-833d-0bd5a41213f2"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40097,7 +40318,7 @@ http_interactions:
             <entry>
                 <id>bf51b878-839d-3473-9d06-21eda9403821</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.575+01:00</published>
+                <published>2022-11-17T09:39:53.436+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/bf51b878-839d-3473-9d06-21eda9403821"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40123,7 +40344,7 @@ http_interactions:
             <entry>
                 <id>5ff62f02-2fad-3b93-92db-9017e2182b95</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.575+01:00</published>
+                <published>2022-11-17T09:39:53.436+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/5ff62f02-2fad-3b93-92db-9017e2182b95"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40149,7 +40370,7 @@ http_interactions:
             <entry>
                 <id>72ab5e49-a05b-3bbb-82fe-aaaf093f34be</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.576+01:00</published>
+                <published>2022-11-17T09:39:53.437+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/72ab5e49-a05b-3bbb-82fe-aaaf093f34be"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40175,7 +40396,7 @@ http_interactions:
             <entry>
                 <id>c8f16508-5966-3220-86a7-4604fcf4a0a4</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.577+01:00</published>
+                <published>2022-11-17T09:39:53.438+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/c8f16508-5966-3220-86a7-4604fcf4a0a4"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40201,7 +40422,7 @@ http_interactions:
             <entry>
                 <id>d42e75d9-b76e-3db0-af74-0fdd349de755</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.577+01:00</published>
+                <published>2022-11-17T09:39:53.438+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/d42e75d9-b76e-3db0-af74-0fdd349de755"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40227,7 +40448,7 @@ http_interactions:
             <entry>
                 <id>3beff9ed-b6c4-364d-a474-5f487f318507</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.578+01:00</published>
+                <published>2022-11-17T09:39:53.439+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/3beff9ed-b6c4-364d-a474-5f487f318507"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40253,7 +40474,7 @@ http_interactions:
             <entry>
                 <id>2db131c1-9229-3709-8c82-558f6749ea05</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.579+01:00</published>
+                <published>2022-11-17T09:39:53.440+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/2db131c1-9229-3709-8c82-558f6749ea05"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40279,7 +40500,7 @@ http_interactions:
             <entry>
                 <id>1049b707-917e-30a4-b20c-bd9926eb7687</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.579+01:00</published>
+                <published>2022-11-17T09:39:53.440+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/1049b707-917e-30a4-b20c-bd9926eb7687"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40305,7 +40526,7 @@ http_interactions:
             <entry>
                 <id>17d58f4f-bcb4-3830-936e-7d0d49756001</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.580+01:00</published>
+                <published>2022-11-17T09:39:53.441+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/17d58f4f-bcb4-3830-936e-7d0d49756001"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40331,7 +40552,7 @@ http_interactions:
             <entry>
                 <id>b4879335-6f9d-3ee4-a649-4a52264f7ec8</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.581+01:00</published>
+                <published>2022-11-17T09:39:53.442+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/b4879335-6f9d-3ee4-a649-4a52264f7ec8"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40357,7 +40578,7 @@ http_interactions:
             <entry>
                 <id>14986eb8-8ab4-39ea-847a-4d362267e924</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.581+01:00</published>
+                <published>2022-11-17T09:39:53.442+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/14986eb8-8ab4-39ea-847a-4d362267e924"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40383,7 +40604,7 @@ http_interactions:
             <entry>
                 <id>b62f7eba-50a0-3e4d-801b-713b449a2259</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.582+01:00</published>
+                <published>2022-11-17T09:39:53.443+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/b62f7eba-50a0-3e4d-801b-713b449a2259"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40409,7 +40630,7 @@ http_interactions:
             <entry>
                 <id>33653557-46d9-3d80-8f67-70dc64c13bcf</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.583+01:00</published>
+                <published>2022-11-17T09:39:53.444+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/33653557-46d9-3d80-8f67-70dc64c13bcf"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40435,7 +40656,7 @@ http_interactions:
             <entry>
                 <id>cf8eb4ea-654c-36e6-9494-5a051bd62a3a</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.583+01:00</published>
+                <published>2022-11-17T09:39:53.444+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/cf8eb4ea-654c-36e6-9494-5a051bd62a3a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40461,7 +40682,7 @@ http_interactions:
             <entry>
                 <id>4898affd-8f4d-3143-a20f-8b98c3b11b75</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.584+01:00</published>
+                <published>2022-11-17T09:39:53.445+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/4898affd-8f4d-3143-a20f-8b98c3b11b75"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40487,7 +40708,7 @@ http_interactions:
             <entry>
                 <id>f5da53c2-9024-3daf-8b38-171ea4856bca</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.585+01:00</published>
+                <published>2022-11-17T09:39:53.446+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/f5da53c2-9024-3daf-8b38-171ea4856bca"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40513,7 +40734,7 @@ http_interactions:
             <entry>
                 <id>dcb4aa2e-2f74-3324-9294-6bd093200496</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.585+01:00</published>
+                <published>2022-11-17T09:39:53.446+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/dcb4aa2e-2f74-3324-9294-6bd093200496"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40539,7 +40760,7 @@ http_interactions:
             <entry>
                 <id>32c28d1d-7f32-3217-b0b9-54b58e3c64d6</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.586+01:00</published>
+                <published>2022-11-17T09:39:53.447+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/32c28d1d-7f32-3217-b0b9-54b58e3c64d6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40565,7 +40786,7 @@ http_interactions:
             <entry>
                 <id>3d682d58-93a1-3b3b-a6b1-f22908d7c444</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.587+01:00</published>
+                <published>2022-11-17T09:39:53.448+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/3d682d58-93a1-3b3b-a6b1-f22908d7c444"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40591,7 +40812,7 @@ http_interactions:
             <entry>
                 <id>8ee7f249-7eee-38cc-9513-091731477648</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.587+01:00</published>
+                <published>2022-11-17T09:39:53.448+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/8ee7f249-7eee-38cc-9513-091731477648"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40617,7 +40838,7 @@ http_interactions:
             <entry>
                 <id>bd9b242f-7c9e-3725-886b-0650afbd6c08</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.588+01:00</published>
+                <published>2022-11-17T09:39:53.449+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/bd9b242f-7c9e-3725-886b-0650afbd6c08"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40643,7 +40864,7 @@ http_interactions:
             <entry>
                 <id>c87c5b89-8cde-3bec-94d1-63ec9200389e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.589+01:00</published>
+                <published>2022-11-17T09:39:53.450+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/c87c5b89-8cde-3bec-94d1-63ec9200389e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40669,7 +40890,7 @@ http_interactions:
             <entry>
                 <id>7941f64a-4f78-3a2e-be68-e616200f1c5a</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.589+01:00</published>
+                <published>2022-11-17T09:39:53.450+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/7941f64a-4f78-3a2e-be68-e616200f1c5a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40695,7 +40916,7 @@ http_interactions:
             <entry>
                 <id>be489a0e-e482-362a-aa71-e4fda7d154fb</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.590+01:00</published>
+                <published>2022-11-17T09:39:53.451+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/be489a0e-e482-362a-aa71-e4fda7d154fb"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40721,7 +40942,7 @@ http_interactions:
             <entry>
                 <id>0400568b-6467-3ed7-8d3f-358b8619a721</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.591+01:00</published>
+                <published>2022-11-17T09:39:53.452+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/0400568b-6467-3ed7-8d3f-358b8619a721"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40747,7 +40968,7 @@ http_interactions:
             <entry>
                 <id>90e639e9-7c9b-3407-8c93-15cce441b774</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.591+01:00</published>
+                <published>2022-11-17T09:39:53.452+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/90e639e9-7c9b-3407-8c93-15cce441b774"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40773,7 +40994,7 @@ http_interactions:
             <entry>
                 <id>99130e06-d057-3612-8957-0f820e53da9d</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.592+01:00</published>
+                <published>2022-11-17T09:39:53.453+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/99130e06-d057-3612-8957-0f820e53da9d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40799,7 +41020,7 @@ http_interactions:
             <entry>
                 <id>6704b059-0681-345c-9e72-4035069eb404</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.593+01:00</published>
+                <published>2022-11-17T09:39:53.454+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/6704b059-0681-345c-9e72-4035069eb404"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40825,7 +41046,7 @@ http_interactions:
             <entry>
                 <id>33624989-6df1-383f-8d00-e1f02f412645</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.593+01:00</published>
+                <published>2022-11-17T09:39:53.455+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/33624989-6df1-383f-8d00-e1f02f412645"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40851,7 +41072,7 @@ http_interactions:
             <entry>
                 <id>122bf3e4-0d56-3170-a686-6fc968f00b46</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.594+01:00</published>
+                <published>2022-11-17T09:39:53.455+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/122bf3e4-0d56-3170-a686-6fc968f00b46"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40877,7 +41098,7 @@ http_interactions:
             <entry>
                 <id>2d330a8c-3eb5-358b-b0da-0883f3a3cad3</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.595+01:00</published>
+                <published>2022-11-17T09:39:53.456+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/2d330a8c-3eb5-358b-b0da-0883f3a3cad3"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40903,7 +41124,7 @@ http_interactions:
             <entry>
                 <id>fc29dfa3-5b2c-3d6f-baab-82fd3473dc44</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.595+01:00</published>
+                <published>2022-11-17T09:39:53.457+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/fc29dfa3-5b2c-3d6f-baab-82fd3473dc44"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40929,7 +41150,7 @@ http_interactions:
             <entry>
                 <id>e4002756-e26f-34df-9314-f55370894eff</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.596+01:00</published>
+                <published>2022-11-17T09:39:53.457+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/e4002756-e26f-34df-9314-f55370894eff"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40955,7 +41176,7 @@ http_interactions:
             <entry>
                 <id>b815d1ba-bca0-3e7a-9735-45504780359f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.597+01:00</published>
+                <published>2022-11-17T09:39:53.458+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/b815d1ba-bca0-3e7a-9735-45504780359f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -40981,7 +41202,7 @@ http_interactions:
             <entry>
                 <id>b3789132-9037-3ff1-bc47-aae1b4914717</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.598+01:00</published>
+                <published>2022-11-17T09:39:53.459+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/b3789132-9037-3ff1-bc47-aae1b4914717"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41007,7 +41228,7 @@ http_interactions:
             <entry>
                 <id>b8f41730-e3ae-3df4-af06-5b14f8856435</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.598+01:00</published>
+                <published>2022-11-17T09:39:53.459+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/b8f41730-e3ae-3df4-af06-5b14f8856435"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41033,7 +41254,7 @@ http_interactions:
             <entry>
                 <id>dc5ca823-6b7c-38a2-b3f7-73eabdbd4a2b</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.599+01:00</published>
+                <published>2022-11-17T09:39:53.460+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/dc5ca823-6b7c-38a2-b3f7-73eabdbd4a2b"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41059,7 +41280,7 @@ http_interactions:
             <entry>
                 <id>2d34fb28-afcd-37a9-9f6f-ca0859ce99f0</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.600+01:00</published>
+                <published>2022-11-17T09:39:53.461+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/2d34fb28-afcd-37a9-9f6f-ca0859ce99f0"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41085,7 +41306,7 @@ http_interactions:
             <entry>
                 <id>a0927489-b422-3848-996c-46eafcf9de1e</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.600+01:00</published>
+                <published>2022-11-17T09:39:53.461+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/a0927489-b422-3848-996c-46eafcf9de1e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41111,7 +41332,7 @@ http_interactions:
             <entry>
                 <id>93c6ac90-44fc-34b0-b084-a5e0ed126581</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.601+01:00</published>
+                <published>2022-11-17T09:39:53.462+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/93c6ac90-44fc-34b0-b084-a5e0ed126581"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41137,7 +41358,7 @@ http_interactions:
             <entry>
                 <id>8872a5f8-9d7e-3c70-a374-052d11d3a39f</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.602+01:00</published>
+                <published>2022-11-17T09:39:53.463+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/8872a5f8-9d7e-3c70-a374-052d11d3a39f"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41163,7 +41384,7 @@ http_interactions:
             <entry>
                 <id>d4e7e5f7-afb5-3560-8ea3-2e087ab7e2cb</id>
                 <title>SharedProcessorPool</title>
-                <published>2022-11-16T11:48:54.602+01:00</published>
+                <published>2022-11-17T09:39:53.463+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/d4e7e5f7-afb5-3560-8ea3-2e087ab7e2cb"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -41188,7 +41409,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:39 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:37 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedMemoryPool
@@ -41213,13 +41434,13 @@ http_interactions:
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-591226868"
+      - '626419601'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
       Content-Length:
-      - '4873'
+      - '4893'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -41228,19 +41449,19 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>6685309d-ed03-3bc5-b0ed-40f28ea541d3</id>
-            <updated>2022-11-16T11:48:54.947+01:00</updated>
+            <updated>2022-11-17T09:39:53.828+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedMemoryPool"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>557f7755-a4dc-30de-816d-387f42dd8fd3</id>
                 <title>SharedMemoryPool</title>
-                <published>2022-11-16T11:48:56.794+01:00</published>
+                <published>2022-11-17T09:39:54.683+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedMemoryPool/557f7755-a4dc-30de-816d-387f42dd8fd3"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
                 </author>
-                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-591226899</etag:etag>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">626419570</etag:etag>
                 <content type="application/vnd.ibm.powervm.uom+xml; type=SharedMemoryPool">
                     <SharedMemoryPool:SharedMemoryPool xmlns:SharedMemoryPool="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
@@ -41249,7 +41470,7 @@ http_interactions:
                     <AtomCreated>1668499116606</AtomCreated>
                 </Atom>
             </Metadata>
-            <CurrentAvailablePoolMemory kxe="false" kb="ROR">768</CurrentAvailablePoolMemory>
+            <CurrentAvailablePoolMemory kxe="false" kb="ROR">701</CurrentAvailablePoolMemory>
             <CurrentMaximumPoolMemory kxe="false" kb="ROR">4096</CurrentMaximumPoolMemory>
             <CurrentPoolMemory kb="ROR" kxe="false">1024</CurrentPoolMemory>
             <MemoryDeduplicationEnabled kxe="false" kb="CUD">false</MemoryDeduplicationEnabled>
@@ -41261,10 +41482,11 @@ http_interactions:
                     <Metadata>
                         <Atom/>
                     </Metadata>
+                    <AssociatedLogicalPartition ksv="V1_2_0" kb="CUA" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/1A4585C1-1B74-445F-A6BE-D41BC26DCD04" rel="related"/>
                     <DeviceName kxe="false" kb="CUR">hdisk5</DeviceName>
                     <DeviceSelectionType kxe="false" kb="ROA">AUTO_SELECTION</DeviceSelectionType>
                     <DeviceSize kxe="false" kb="CUR">100</DeviceSize>
-                    <DeviceState kb="ROR" kxe="false">Inactive</DeviceState>
+                    <DeviceState kb="ROR" kxe="false">Active</DeviceState>
                     <DeviceType kxe="false" kb="ROR">Phys</DeviceType>
                     <LocationCode kb="ROR" kxe="false">U78CB.001.WZS09SL-P1-C12-T2-W500507680B215660-L1000000000000</LocationCode>
                     <RedundancyCapable kb="ROR" kxe="false">true</RedundancyCapable>
@@ -41287,20 +41509,19 @@ http_interactions:
                     <UniqueDeviceID kb="ROA" kxe="false">01MUlCTSAgICAgSVBSLTAgICA2QUI0MDcwMDAwMDAwMDIw</UniqueDeviceID>
                 </ReservedStorageDevice>
             </FreeMemoryDevicesFromPagingServicePartitionOne>
-            <PendingAvailablePoolMemory kb="ROR" kxe="false">768</PendingAvailablePoolMemory>
+            <PendingAvailablePoolMemory kb="ROR" kxe="false">701</PendingAvailablePoolMemory>
             <PendingMaximumPoolMemory kxe="false" kb="CUD">4096</PendingMaximumPoolMemory>
             <PendingPoolMemory kxe="false" kb="CUD">1024</PendingPoolMemory>
             <PoolID kxe="false" kb="ROR">0</PoolID>
             <PoolSize kb="CUR" kxe="false">1024</PoolSize>
             <PagingServicePartitionOne kb="CUR" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/0D323064-36E2-455A-AB06-46BD079AD545" rel="related"/>
-            <PagingServicePartitionTwo kb="CUR" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/VirtualIOServer/1ABB7000-4A15-4749-9EAE-CD0A0827CDFE" rel="related"/>
-            <SystemFirmwarePoolMemory kb="ROR" kxe="false">256</SystemFirmwarePoolMemory>
+            <SystemFirmwarePoolMemory kb="ROR" kxe="false">263</SystemFirmwarePoolMemory>
         </SharedMemoryPool:SharedMemoryPool>
                 </content>
             </entry>
         </feed>
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:42 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/SharedMemoryPool
@@ -41338,7 +41559,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:42 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedMemoryPool
@@ -41376,7 +41597,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:42 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:39 GMT
 - request:
     method: delete
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -41410,5 +41631,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Wed, 16 Nov 2022 10:17:42 GMT
+  recorded_at: Thu, 17 Nov 2022 08:08:39 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/manageiq/providers/ibm_power_hmc/infra_manager/refresher_lpar_646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_power_hmc/infra_manager/refresher_lpar_646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3.yml
@@ -13,8 +13,7 @@ http_interactions:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonRequest
-      X-Api-Session:
-      - ''
+      X-Api-Session: xxx
       Content-Length:
       - '176'
       Accept-Encoding:
@@ -26,18 +25,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673385
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonResponse
       Content-Length:
       - '576'
-      Set-Cookie:
-      - CCFWSESSION=78D70F984263C0B066223EE70711896A; Path=/; Secure; HttpOnly
-      - JSESSIONID=0000jzkm9ajvQlYH3wCe7TdegDy:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:47:38 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -50,10 +41,10 @@ http_interactions:
             <Metadata>
                 <Atom/>
             </Metadata>
-            <X-API-Session kb="ROR" kxe="false">NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_9L3iioapNp1Gk4IcASJbPESlrTfSPiez_r8uB7NATmoSjDUBAcZACcgiYEkPtelfjLMB1dwzg71r3QwTA0pgdjPUCClKMjBAo65i6sWkBfyuFlKsGHOLq40aZFaIxf3E3390vcqAD2SsNfA285tc0dCfvfw0CQdNO2A0VMm7uZdacbvzgRRYMBkJTVsMza8=</X-API-Session>
+            <X-API-Session>xxx</X-API-Session>
         </LogonResponse>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:17 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3
@@ -65,8 +56,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_9L3iioapNp1Gk4IcASJbPESlrTfSPiez_r8uB7NATmoSjDUBAcZACcgiYEkPtelfjLMB1dwzg71r3QwTA0pgdjPUCClKMjBAo65i6sWkBfyuFlKsGHOLq40aZFaIxf3E3390vcqAD2SsNfA285tc0dCfvfw0CQdNO2A0VMm7uZdacbvzgRRYMBkJTVsMza8=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -76,21 +66,12 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673386
       Content-Type:
       - application/atom+xml
-      X-Transactionrecord-Uuid:
-      - 6ce4e6bd-2676-4277-9407-6f9b594d2038
       Content-Length:
       - '1555'
-      Set-Cookie:
-      - JSESSIONID=0000R6difmhP_fUE_4E6NzbJwmP:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
       Connection:
       - Close
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -100,9 +81,9 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>6dc9b37c-5a2e-4cfa-852f-4db6b59124a9</id>
+            <id>afb00aac-e5c8-4998-a13c-723be965bd39</id>
             <title>HttpErrorResponse</title>
-            <published>2022-10-24T14:47:39.006+01:00</published>
+            <published>2022-11-17T09:40:33.548+01:00</published>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
@@ -116,12 +97,12 @@ http_interactions:
             <ReasonCode kb="ROR" kxe="false">The supplied URI does not identify a known resource.</ReasonCode>
             <Message kb="ROO" kxe="false">REST000B The URL presented to the Management Console REST Web Services is not valid.</Message>
             <RequestBody kb="ROO" kxe="false"/>
-            <RequestHeaders kxe="false" kb="ROO">{Accept=*/*, X-API-Session=*******, X-Transaction-ID=XT12673386, User-Agent=rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137, Host=ibm-power-hmc-hostname:12443, Accept-Encoding=gzip;q=1.0,deflate;q=0.6,identity;q=0.3}</RequestHeaders>
+            <RequestHeaders kxe="false" kb="ROO">{Accept=*/*, X-API-Session=*******, X-Transaction-ID=XT10117435, User-Agent=rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137, Host=ibm-power-hmc-hostname:12443, Accept-Encoding=gzip;q=1.0,deflate;q=0.6,identity;q=0.3}</RequestHeaders>
         </HttpErrorResponse:HttpErrorResponse>
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:17 GMT
 - request:
     method: delete
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -133,8 +114,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_9L3iioapNp1Gk4IcASJbPESlrTfSPiez_r8uB7NATmoSjDUBAcZACcgiYEkPtelfjLMB1dwzg71r3QwTA0pgdjPUCClKMjBAo65i6sWkBfyuFlKsGHOLq40aZFaIxf3E3390vcqAD2SsNfA285tc0dCfvfw0CQdNO2A0VMm7uZdacbvzgRRYMBkJTVsMza8=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -144,21 +124,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673387
       Content-Language:
       - en-US
       Content-Length:
       - '0'
-      Set-Cookie:
-      - CCFWSESSION=78D70F984263C0B066223EE70711896A; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/"; Secure
-      - JSESSIONID=0000z_odWJNKsAljgWjRhvYNZkf:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      - JSESSIONID=78D70F984263C0B066223EE70711896A; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/hmc"; Secure
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -167,7 +136,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:15 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:17 GMT
 - request:
     method: put
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -181,8 +150,7 @@ http_interactions:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonRequest
-      X-Api-Session:
-      - ''
+      X-Api-Session: xxx
       Content-Length:
       - '176'
       Accept-Encoding:
@@ -194,18 +162,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673388
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonResponse
       Content-Length:
       - '576'
-      Set-Cookie:
-      - CCFWSESSION=4AFC07D447A7269F103320F695B145AF; Path=/; Secure; HttpOnly
-      - JSESSIONID=0000-_4wER7bAdWKqvbWQVz5dcL:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -218,10 +178,10 @@ http_interactions:
             <Metadata>
                 <Atom/>
             </Metadata>
-            <X-API-Session kb="ROR" kxe="false">NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaDa9TzFA0h4WDtk9OZ1ZyjJ8yc6wLrNETmG7V8SpKfKV8kOq7dlxBXDKnmeZJvgy05lsLWybS_TGPIQQTIfEs_h_WcV1EsctVQMs31ISnxPUO5knmUXrcKCJYhO52t3Oncq26YeqnNRn7Ar8AyyG69T0ZjwRMlkShGPow21KC67bS7ElPcR3m8oJduMIBdk_54=</X-API-Session>
+            <X-API-Session>xxx</X-API-Session>
         </LogonResponse>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:16 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:18 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3?group=None
@@ -233,8 +193,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaDa9TzFA0h4WDtk9OZ1ZyjJ8yc6wLrNETmG7V8SpKfKV8kOq7dlxBXDKnmeZJvgy05lsLWybS_TGPIQQTIfEs_h_WcV1EsctVQMs31ISnxPUO5knmUXrcKCJYhO52t3Oncq26YeqnNRn7Ar8AyyG69T0ZjwRMlkShGPow21KC67bS7ElPcR3m8oJduMIBdk_54=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -244,27 +203,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673389
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-496987924"
+      - "-1585670656"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 02a07d0c-e857-4f4c-9f26-e1365dc098c2
       Content-Length:
-      - '12874'
-      Set-Cookie:
-      - JSESSIONID=0000CYBPyyMV37NVdi9LzUF4GIV:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
+      - '13192'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -274,19 +222,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3</id>
             <title>LogicalPartition</title>
-            <published>2022-10-24T14:47:39.487+01:00</published>
+            <published>2022-11-17T09:40:34.040+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-496987924</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1585670656</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                 <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3</AtomID>
-                    <AtomCreated>1665051502752</AtomCreated>
+                    <AtomCreated>1667813811261</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
@@ -423,9 +371,11 @@ http_interactions:
             <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
             <ReferenceCode kb="ROO" kxe="true"/>
+            <AssociatedGroups ksv="V1_2_0" kb="ROO" kxe="false">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/Group/73254f6f-5977-4642-92cd-3cdc8a0632a0" rel="related"/>
+            </AssociatedGroups>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
-            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Valid</MigrationStorageViosDataStatus>
-            <MigrationStorageViosDataTimestamp ksv="V1_3_0" kb="ROR" kxe="false">Thu Oct 06 12:20:07 CEST 2022</MigrationStorageViosDataTimestamp>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Update_Failed</MigrationStorageViosDataStatus>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
             <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
             <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
@@ -437,13 +387,123 @@ http_interactions:
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualFibreChannelClientAdapter/a8906786-1431-39c3-b7e3-db0b579377e1" rel="related"/>
             </VirtualFibreChannelClientAdapters>
             <VirtualSCSIClientAdapters kb="CUR" kxe="false">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualSCSIClientAdapter/9a2b986f-51be-3d49-83ef-dce935677b18" rel="related"/>
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualSCSIClientAdapter/8ad1e9da-34aa-30f4-b9b4-274b9598ae8a" rel="related"/>
             </VirtualSCSIClientAdapters>
         </LogicalPartition:LogicalPartition>
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:16 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:18 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/Group
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - "-1146424212"
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '4659'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>3d9231ee-e5bc-38e7-b59c-00f9a1384022</id>
+            <updated>2022-11-17T09:40:34.135+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>24f0e0fe-7879-4050-be45-a6e76426423d</id>
+                <title>Group</title>
+                <published>2022-11-17T09:40:34.137+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group/24f0e0fe-7879-4050-be45-a6e76426423d"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1676141590</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=Group">
+                    <Group:Group xmlns:Group="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_2_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>24f0e0fe-7879-4050-be45-a6e76426423d</AtomID>
+                    <AtomCreated>1668674434136</AtomCreated>
+                </Atom>
+            </Metadata>
+            <GroupUUID ksv="V1_2_0" kb="ROR" kxe="false">24f0e0fe-7879-4050-be45-a6e76426423d</GroupUUID>
+            <GroupName ksv="V1_2_0" kb="COR" kxe="false">mon_groupe</GroupName>
+            <GroupDescription ksv="V1_2_0" kxe="false" kb="COR"/>
+            <GroupColor ksv="V1_2_0" kb="COR" kxe="false">Grey</GroupColor>
+            <AssociatedLogicalPartitions ksv="V1_2_0" kb="COD" kxe="false">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/00000000-0000-0000-0000-000000000000" rel="related"/>
+            </AssociatedLogicalPartitions>
+            <AssociatedVirtualIOServers ksv="V1_2_0" kxe="false" kb="COD">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371" rel="related"/>
+            </AssociatedVirtualIOServers>
+            <AssociatedManagedSystems ksv="V1_2_0" kb="COD" kxe="false"/>
+        </Group:Group>
+                </content>
+            </entry>
+            <entry>
+                <id>73254f6f-5977-4642-92cd-3cdc8a0632a0</id>
+                <title>Group</title>
+                <published>2022-11-17T09:40:34.138+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group/73254f6f-5977-4642-92cd-3cdc8a0632a0"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-725643435</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=Group">
+                    <Group:Group xmlns:Group="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_2_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>73254f6f-5977-4642-92cd-3cdc8a0632a0</AtomID>
+                    <AtomCreated>1668674434136</AtomCreated>
+                </Atom>
+            </Metadata>
+            <GroupUUID ksv="V1_2_0" kb="ROR" kxe="false">73254f6f-5977-4642-92cd-3cdc8a0632a0</GroupUUID>
+            <GroupName ksv="V1_2_0" kb="COR" kxe="false">ManageIQ</GroupName>
+            <GroupDescription ksv="V1_2_0" kxe="false" kb="COR"/>
+            <GroupColor ksv="V1_2_0" kb="COR" kxe="false">Orange</GroupColor>
+            <AssociatedLogicalPartitions ksv="V1_2_0" kb="COD" kxe="false">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3" rel="related"/>
+            </AssociatedLogicalPartitions>
+            <AssociatedVirtualIOServers ksv="V1_2_0" kxe="false" kb="COD">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E" rel="related"/>
+            </AssociatedVirtualIOServers>
+            <AssociatedManagedSystems ksv="V1_2_0" kb="COD" kxe="false"/>
+        </Group:Group>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:09:18 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/ClientNetworkAdapter
@@ -455,8 +515,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaDa9TzFA0h4WDtk9OZ1ZyjJ8yc6wLrNETmG7V8SpKfKV8kOq7dlxBXDKnmeZJvgy05lsLWybS_TGPIQQTIfEs_h_WcV1EsctVQMs31ISnxPUO5knmUXrcKCJYhO52t3Oncq26YeqnNRn7Ar8AyyG69T0ZjwRMlkShGPow21KC67bS7ElPcR3m8oJduMIBdk_54=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -466,27 +525,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673390
       Content-Type:
       - application/atom+xml
       Etag:
       - "-759463070"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 158981f4-ede1-41a1-9463-d1131caaae76
       Content-Length:
       - '3288'
-      Set-Cookie:
-      - JSESSIONID=0000T0DP_c3XhCe5dM-nj1DDwF_:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -495,14 +543,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>e3f2bc22-7672-3b34-9540-db3e249c0e02</id>
-            <updated>2022-10-24T14:47:39.601+01:00</updated>
+            <updated>2022-11-17T09:40:34.195+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>343b5c2d-f80e-3749-9f28-47881f8fb814</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-10-24T14:47:39.622+01:00</published>
+                <published>2022-11-17T09:40:34.216+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/ClientNetworkAdapter/343b5c2d-f80e-3749-9f28-47881f8fb814"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -513,7 +561,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>343b5c2d-f80e-3749-9f28-47881f8fb814</AtomID>
-                    <AtomCreated>1665051576423</AtomCreated>
+                    <AtomCreated>1668431880221</AtomCreated>
                 </Atom>
             </Metadata>
             <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.103341V-V16-C2</DynamicReconfigurationConnectorName>
@@ -539,7 +587,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:16 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:18 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualSCSIClientAdapter
@@ -551,8 +599,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaDa9TzFA0h4WDtk9OZ1ZyjJ8yc6wLrNETmG7V8SpKfKV8kOq7dlxBXDKnmeZJvgy05lsLWybS_TGPIQQTIfEs_h_WcV1EsctVQMs31ISnxPUO5knmUXrcKCJYhO52t3Oncq26YeqnNRn7Ar8AyyG69T0ZjwRMlkShGPow21KC67bS7ElPcR3m8oJduMIBdk_54=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -562,27 +609,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673392
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-782040701"
+      - "-597406687"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 98788847-b257-40d9-90cf-0418a8c0be8b
       Content-Length:
-      - '3817'
-      Set-Cookie:
-      - JSESSIONID=0000y2098_m0pkz2wD7VlvRpcTa:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
+      - '7034'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -591,14 +627,60 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>7c9b36e0-4e8a-3fa5-af20-6776553f7b33</id>
-            <updated>2022-10-24T14:47:39.676+01:00</updated>
+            <updated>2022-11-17T09:40:34.270+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualSCSIClientAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
+                <id>9a2b986f-51be-3d49-83ef-dce935677b18</id>
+                <title>VirtualSCSIClientAdapter</title>
+                <published>2022-11-17T09:40:34.290+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualSCSIClientAdapter/9a2b986f-51be-3d49-83ef-dce935677b18"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-2072254076</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=VirtualSCSIClientAdapter">
+                    <VirtualSCSIClientAdapter:VirtualSCSIClientAdapter xmlns:VirtualSCSIClientAdapter="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>9a2b986f-51be-3d49-83ef-dce935677b18</AtomID>
+                    <AtomCreated>1668674434284</AtomCreated>
+                </Atom>
+            </Metadata>
+            <AdapterType kb="ROR" kxe="false">Client</AdapterType>
+            <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.103341V-V16-C5</DynamicReconfigurationConnectorName>
+            <LocationCode kxe="false" kb="ROR">U8286.42A.103341V-V16-C5</LocationCode>
+            <LocalPartitionID kxe="false" kb="CUR">16</LocalPartitionID>
+            <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
+            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VirtualSlotNumber kb="COD" kxe="false">5</VirtualSlotNumber>
+            <RemoteLogicalPartitionID kxe="false" kb="CUR">1</RemoteLogicalPartitionID>
+            <RemoteSlotNumber kxe="false" kb="CUA">8</RemoteSlotNumber>
+            <ServerLocationCode kb="CUR" kxe="false">U8286.42A.103341V-V1-C8</ServerLocationCode>
+            <ServerAdapter kb="CUD" kxe="false" schemaVersion="V1_5_0">
+                <Metadata>
+                    <Atom/>
+                </Metadata>
+                <AdapterType kb="ROR" kxe="false">Server</AdapterType>
+                <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.103341V-V1-C8</DynamicReconfigurationConnectorName>
+                <LocationCode kxe="false" kb="ROR">U8286.42A.103341V-V1-C8</LocationCode>
+                <LocalPartitionID kxe="false" kb="CUR">1</LocalPartitionID>
+                <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
+                <VariedOn kxe="true" kb="CUD">true</VariedOn>
+                <VirtualSlotNumber kb="COD" kxe="false">8</VirtualSlotNumber>
+                <RemoteLogicalPartitionID kxe="false" kb="CUR">16</RemoteLogicalPartitionID>
+                <RemoteSlotNumber kxe="false" kb="CUA">5</RemoteSlotNumber>
+                <ServerLocationCode kb="CUR" kxe="false">U8286.42A.103341V-V16-C5</ServerLocationCode>
+            </ServerAdapter>
+            <ConnectingPartition ksv="V1_3_0" kxe="false" kb="CUR" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/VirtualIOServer/4154B185-22EB-4D16-B1F4-D9F714496C98" rel="related"/>
+        </VirtualSCSIClientAdapter:VirtualSCSIClientAdapter>
+                </content>
+            </entry>
+            <entry>
                 <id>8ad1e9da-34aa-30f4-b9b4-274b9598ae8a</id>
                 <title>VirtualSCSIClientAdapter</title>
-                <published>2022-10-24T14:47:39.695+01:00</published>
+                <published>2022-11-17T09:40:34.291+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3/VirtualSCSIClientAdapter/8ad1e9da-34aa-30f4-b9b4-274b9598ae8a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -609,7 +691,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>8ad1e9da-34aa-30f4-b9b4-274b9598ae8a</AtomID>
-                    <AtomCreated>1666619259688</AtomCreated>
+                    <AtomCreated>1668674434289</AtomCreated>
                 </Atom>
             </Metadata>
             <AdapterType kb="ROR" kxe="false">Client</AdapterType>
@@ -643,7 +725,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:16 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:18 GMT
 - request:
     method: delete
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -655,8 +737,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaDa9TzFA0h4WDtk9OZ1ZyjJ8yc6wLrNETmG7V8SpKfKV8kOq7dlxBXDKnmeZJvgy05lsLWybS_TGPIQQTIfEs_h_WcV1EsctVQMs31ISnxPUO5knmUXrcKCJYhO52t3Oncq26YeqnNRn7Ar8AyyG69T0ZjwRMlkShGPow21KC67bS7ElPcR3m8oJduMIBdk_54=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -666,21 +747,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673394
       Content-Language:
       - en-US
       Content-Length:
       - '0'
-      Set-Cookie:
-      - CCFWSESSION=4AFC07D447A7269F103320F695B145AF; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/"; Secure
-      - JSESSIONID=0000NymtB5F9ftDgzJKwDDiDQGW:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      - JSESSIONID=4AFC07D447A7269F103320F695B145AF; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/hmc"; Secure
-      Date:
-      - Mon, 24 Oct 2022 13:47:39 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -689,5 +759,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:16:16 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:18 GMT
 recorded_with: VCR 5.1.0

--- a/spec/vcr_cassettes/manageiq/providers/ibm_power_hmc/infra_manager/refresher_vios_4165A16F-0766-40F3-B9E2-7272E1910F2E.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ibm_power_hmc/infra_manager/refresher_vios_4165A16F-0766-40F3-B9E2-7272E1910F2E.yml
@@ -13,8 +13,7 @@ http_interactions:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonRequest
-      X-Api-Session:
-      - ''
+      X-Api-Session: xxx
       Content-Length:
       - '176'
       Accept-Encoding:
@@ -26,18 +25,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673527
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonResponse
       Content-Length:
       - '576'
-      Set-Cookie:
-      - CCFWSESSION=BFE85FD9D90237023AD342C59BB85470; Path=/; Secure; HttpOnly
-      - JSESSIONID=0000k4pz_EVOI8WxSLHiGNdx8b9:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:34 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -50,10 +41,10 @@ http_interactions:
             <Metadata>
                 <Atom/>
             </Metadata>
-            <X-API-Session kb="ROR" kxe="false">NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaBFGL1ySWSqmtJcapIWjGWRIz6NaOIYJCmznww1EUSPhcXkTnJtVCZIUopeg2XcwZwY009KwAPf87VB9AYGV6nGj6Dmmo4jpMoLSBUdoUMlA-wXvJu1YHXgcoTxtwGSfMR-8k8qfijtOVYTK2J4hdr8YWAOhB44E0KHcENwTiUXTnNGHsk2K3Tgsbrn6SMiHD0=</X-API-Session>
+            <X-API-Session>xxx</X-API-Session>
         </LogonResponse>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:10 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:36 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E
@@ -65,8 +56,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaBFGL1ySWSqmtJcapIWjGWRIz6NaOIYJCmznww1EUSPhcXkTnJtVCZIUopeg2XcwZwY009KwAPf87VB9AYGV6nGj6Dmmo4jpMoLSBUdoUMlA-wXvJu1YHXgcoTxtwGSfMR-8k8qfijtOVYTK2J4hdr8YWAOhB44E0KHcENwTiUXTnNGHsk2K3Tgsbrn6SMiHD0=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -76,27 +66,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673528
       Content-Type:
       - application/atom+xml
       Etag:
-      - '370396982'
+      - '1153485861'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:34 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 229c8360-1b5a-4e32-884c-ed528116c5b4
-      Set-Cookie:
-      - JSESSIONID=0000WuN6pE7sCYh6-6aDLgxWO4w:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
       Transfer-Encoding:
       - chunked
-      Date:
-      - Mon, 24 Oct 2022 13:48:34 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -106,19 +85,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>4165A16F-0766-40F3-B9E2-7272E1910F2E</id>
             <title>VirtualIOServer</title>
-            <published>2022-10-24T14:48:34.752+01:00</published>
+            <published>2022-11-17T09:40:53.060+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">370396982</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1153485861</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=VirtualIOServer">
                 <VirtualIOServer:VirtualIOServer xmlns:VirtualIOServer="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>4165A16F-0766-40F3-B9E2-7272E1910F2E</AtomID>
-                    <AtomCreated>1665051470457</AtomCreated>
+                    <AtomCreated>1667815510498</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
@@ -506,7 +485,7 @@ http_interactions:
             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
         </PhysicalFibreChannelPort>
                                     </PhysicalFibreChannelPorts>
@@ -596,6 +575,9 @@ http_interactions:
             <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
             <ReferenceCode kb="ROO" kxe="true"/>
+            <AssociatedGroups ksv="V1_2_0" kb="ROO" kxe="false">
+                <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E/Group/73254f6f-5977-4642-92cd-3cdc8a0632a0" rel="related"/>
+            </AssociatedGroups>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">true</PowerOnWithHypervisor>
             <APICapable kb="CUD" kxe="false">true</APICapable>
             <IsVNICCapable ksv="V1_3_0" kxe="false" kb="CUD">true</IsVNICCapable>
@@ -1050,7 +1032,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1078,7 +1060,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1112,7 +1094,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1140,7 +1122,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1174,7 +1156,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1202,7 +1184,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1236,7 +1218,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1264,7 +1246,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1298,7 +1280,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1326,7 +1308,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1360,7 +1342,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1388,7 +1370,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1422,7 +1404,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1450,7 +1432,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1469,7 +1451,7 @@ http_interactions:
                         <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V9-C5</LocationCode>
                         <LocalPartitionID kxe="false" kb="CUR">9</LocalPartitionID>
                         <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-                        <VariedOn kxe="true" kb="CUD">true</VariedOn>
+                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
                         <VirtualSlotNumber kb="COD" kxe="false">5</VirtualSlotNumber>
                         <ConnectingPartitionID kxe="false" kb="CUR">1</ConnectingPartitionID>
                         <ConnectingVirtualSlotNumber kb="CUR" kxe="false">6</ConnectingVirtualSlotNumber>
@@ -1484,7 +1466,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1512,7 +1494,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1531,7 +1513,7 @@ http_interactions:
                         <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V9-C3</LocationCode>
                         <LocalPartitionID kxe="false" kb="CUR">9</LocalPartitionID>
                         <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-                        <VariedOn kxe="true" kb="CUD">true</VariedOn>
+                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
                         <VirtualSlotNumber kb="COD" kxe="false">3</VirtualSlotNumber>
                         <ConnectingPartitionID kxe="false" kb="CUR">1</ConnectingPartitionID>
                         <ConnectingVirtualSlotNumber kb="CUR" kxe="false">4</ConnectingVirtualSlotNumber>
@@ -1583,7 +1565,7 @@ http_interactions:
                         <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                         <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                         <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                        <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                        <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                         <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                     </Port>
                     <ServerAdapter kxe="false" kb="CUR" schemaVersion="V1_5_0">
@@ -1611,7 +1593,7 @@ http_interactions:
                             <UniqueDeviceID kb="ROR" kxe="false">1aU78C9.001.WZS01L9-P1-C3-T2</UniqueDeviceID>
                             <WWPN kb="CUR" kxe="false">100000109b66a79b</WWPN>
                             <WWNN ksv="V1_3_0" kb="ROO" kxe="false">200000109b66a79b</WWNN>
-                            <AvailablePorts kb="ROR" kxe="true">57</AvailablePorts>
+                            <AvailablePorts kb="ROR" kxe="true">58</AvailablePorts>
                             <TotalPorts kxe="true" kb="ROR">64</TotalPorts>
                         </PhysicalPort>
                     </ServerAdapter>
@@ -1765,7 +1747,7 @@ http_interactions:
                         <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V19-C3</LocationCode>
                         <LocalPartitionID kxe="false" kb="CUR">19</LocalPartitionID>
                         <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
-                        <VariedOn kxe="true" kb="CUD">true</VariedOn>
+                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
                         <VirtualSlotNumber kb="COD" kxe="false">3</VirtualSlotNumber>
                         <RemoteLogicalPartitionID kxe="false" kb="CUR">1</RemoteLogicalPartitionID>
                         <RemoteSlotNumber kxe="false" kb="CUA">38</RemoteSlotNumber>
@@ -1835,7 +1817,7 @@ http_interactions:
                         <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V9-C4</LocationCode>
                         <LocalPartitionID kxe="false" kb="CUR">9</LocalPartitionID>
                         <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-                        <VariedOn kxe="true" kb="CUD">true</VariedOn>
+                        <VariedOn kxe="true" kb="CUD">false</VariedOn>
                         <VirtualSlotNumber kb="COD" kxe="false">4</VirtualSlotNumber>
                         <RemoteLogicalPartitionID kxe="false" kb="CUR">1</RemoteLogicalPartitionID>
                         <RemoteSlotNumber kxe="false" kb="CUA">5</RemoteSlotNumber>
@@ -2080,7 +2062,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:11 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:37 GMT
 - request:
     method: delete
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -2092,8 +2074,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaBFGL1ySWSqmtJcapIWjGWRIz6NaOIYJCmznww1EUSPhcXkTnJtVCZIUopeg2XcwZwY009KwAPf87VB9AYGV6nGj6Dmmo4jpMoLSBUdoUMlA-wXvJu1YHXgcoTxtwGSfMR-8k8qfijtOVYTK2J4hdr8YWAOhB44E0KHcENwTiUXTnNGHsk2K3Tgsbrn6SMiHD0=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2103,21 +2084,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673531
       Content-Language:
       - en-US
       Content-Length:
       - '0'
-      Set-Cookie:
-      - CCFWSESSION=BFE85FD9D90237023AD342C59BB85470; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/"; Secure
-      - JSESSIONID=0000ds6ypZX8ACfrRLwIQOmbBXu:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      - JSESSIONID=BFE85FD9D90237023AD342C59BB85470; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/hmc"; Secure
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -2126,7 +2096,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:11 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:37 GMT
 - request:
     method: put
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -2140,8 +2110,7 @@ http_interactions:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonRequest
-      X-Api-Session:
-      - ''
+      X-Api-Session: xxx
       Content-Length:
       - '176'
       Accept-Encoding:
@@ -2153,18 +2122,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673532
       Content-Type:
       - application/vnd.ibm.powervm.web+xml; type=LogonResponse
       Content-Length:
       - '576'
-      Set-Cookie:
-      - CCFWSESSION=AB0D1B044746B0DDC8A157C5D6245C29; Path=/; Secure; HttpOnly
-      - JSESSIONID=0000YLs-hFEb3vS3QqjktKPORza:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -2177,10 +2138,10 @@ http_interactions:
             <Metadata>
                 <Atom/>
             </Metadata>
-            <X-API-Session kb="ROR" kxe="false">NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=</X-API-Session>
+            <X-API-Session>xxx</X-API-Session>
         </LogonResponse>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:12 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4165A16F-0766-40F3-B9E2-7272E1910F2E?group=None
@@ -2192,8 +2153,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2203,21 +2163,12 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673533
       Content-Type:
       - application/atom+xml
-      X-Transactionrecord-Uuid:
-      - dd1871e7-9fbc-4891-9ae4-18c1ea82f7f6
       Content-Length:
       - '1556'
-      Set-Cookie:
-      - JSESSIONID=0000IQFeDRWDWGM96UQ3kGtMThr:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
       Connection:
       - Close
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -2227,9 +2178,9 @@ http_interactions:
       string: |2
 
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
-            <id>122bebb1-1a2f-486f-968e-7ac3e1d7b8c0</id>
+            <id>32a61c86-d8f9-4073-80a0-e0fe61f23223</id>
             <title>HttpErrorResponse</title>
-            <published>2022-10-24T14:48:35.489+01:00</published>
+            <published>2022-11-17T09:40:53.895+01:00</published>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
@@ -2243,12 +2194,12 @@ http_interactions:
             <ReasonCode kb="ROR" kxe="false">The supplied URI does not identify a known resource.</ReasonCode>
             <Message kb="ROO" kxe="false">REST000B The URL presented to the Management Console REST Web Services is not valid.</Message>
             <RequestBody kb="ROO" kxe="false"/>
-            <RequestHeaders kxe="false" kb="ROO">{Accept=*/*, X-API-Session=*******, X-Transaction-ID=XT12673533, User-Agent=rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137, Host=ibm-power-hmc-hostname:12443, Accept-Encoding=gzip;q=1.0,deflate;q=0.6,identity;q=0.3}</RequestHeaders>
+            <RequestHeaders kxe="false" kb="ROO">{Accept=*/*, X-API-Session=*******, X-Transaction-ID=XT10117449, User-Agent=rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137, Host=ibm-power-hmc-hostname:12443, Accept-Encoding=gzip;q=1.0,deflate;q=0.6,identity;q=0.3}</RequestHeaders>
         </HttpErrorResponse:HttpErrorResponse>
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:12 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874?group=None
@@ -2260,8 +2211,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2271,27 +2221,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673534
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-1972991672"
+      - "-790447182"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 6a00778f-42d8-4440-81cf-2ea4ea6133e2
       Content-Length:
-      - '12306'
-      Set-Cookie:
-      - JSESSIONID=0000arV3o0vIEfXsZIFXTKpCUbW:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
+      - '12416'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -2301,19 +2240,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>4636108C-4424-4490-808A-9C6764F2B874</id>
             <title>LogicalPartition</title>
-            <published>2022-10-24T14:48:35.610+01:00</published>
+            <published>2022-11-17T09:40:54.018+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1972991672</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-790447182</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                 <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>4636108C-4424-4490-808A-9C6764F2B874</AtomID>
-                    <AtomCreated>1665051509208</AtomCreated>
+                    <AtomCreated>1667813811279</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
@@ -2450,6 +2389,7 @@ http_interactions:
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
             <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">No_Data</MigrationStorageViosDataStatus>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
             <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
             <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
@@ -2464,7 +2404,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:12 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE?group=None
@@ -2476,8 +2416,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2487,27 +2426,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673535
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-1556303533"
+      - '1856585582'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - d2899336-8045-44cd-af28-3ddbd8cc3751
       Content-Length:
-      - '12047'
-      Set-Cookie:
-      - JSESSIONID=0000vnhjTiS6YwpZS-QoTOy_0_4:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
+      - '12293'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -2517,19 +2445,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>7F840DA7-9563-40B0-B913-DDDF3368BCEE</id>
             <title>LogicalPartition</title>
-            <published>2022-10-24T14:48:35.760+01:00</published>
+            <published>2022-11-17T09:40:54.190+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1556303533</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">1856585582</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                 <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>7F840DA7-9563-40B0-B913-DDDF3368BCEE</AtomID>
-                    <AtomCreated>1665051509642</AtomCreated>
+                    <AtomCreated>1667813811284</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
@@ -2664,6 +2592,8 @@ http_interactions:
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
             <ReferenceCode kb="ROO" kxe="true">00000000</ReferenceCode>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Valid</MigrationStorageViosDataStatus>
+            <MigrationStorageViosDataTimestamp ksv="V1_3_0" kb="ROR" kxe="false">Mon Nov 07 11:10:04 CET 2022</MigrationStorageViosDataTimestamp>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
             <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
             <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
@@ -2678,7 +2608,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:12 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C?group=None
@@ -2690,8 +2620,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2701,27 +2630,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673536
       Content-Type:
       - application/atom+xml
       Etag:
-      - '670991628'
+      - "-1979886294"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - d2be2125-6c72-4c16-995e-566ba2370eb8
       Content-Length:
-      - '12055'
-      Set-Cookie:
-      - JSESSIONID=0000Jwj0Skm8Wi4yTQNK8Fstgzp:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
+      - '12305'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -2731,19 +2649,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>51B91FAB-1C58-4B9C-B239-878C01D5089C</id>
             <title>LogicalPartition</title>
-            <published>2022-10-24T14:48:35.917+01:00</published>
+            <published>2022-11-17T09:40:54.359+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">670991628</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1979886294</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                 <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>51B91FAB-1C58-4B9C-B239-878C01D5089C</AtomID>
-                    <AtomCreated>1665051509544</AtomCreated>
+                    <AtomCreated>1667813811282</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
@@ -2811,7 +2729,7 @@ http_interactions:
                 <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
                 <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
                 <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
-                <RuntimeMemory kxe="false" kb="ROR">65536</RuntimeMemory>
+                <RuntimeMemory kxe="false" kb="ROR">256</RuntimeMemory>
                 <RuntimeMinimumMemory kxe="false" kb="ROR">32768</RuntimeMinimumMemory>
                 <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
             </PartitionMemoryConfiguration>
@@ -2850,21 +2768,21 @@ http_interactions:
                     <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
                     <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
                     <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">16</CurrentMaximumVirtualProcessors>
-                    <RuntimeProcessingUnits kxe="false" kb="ROR">1</RuntimeProcessingUnits>
-                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
+                    <RuntimeProcessingUnits kxe="false" kb="ROR">0</RuntimeProcessingUnits>
+                    <RuntimeUncappedWeight kb="ROR" kxe="false">0</RuntimeUncappedWeight>
                 </CurrentSharedProcessorConfiguration>
             </PartitionProcessorConfiguration>
             <PartitionProfiles kxe="false" kb="CUD">
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/LogicalPartitionProfile/054be554-8131-38dd-8347-d257e5f1ab1e" rel="related"/>
             </PartitionProfiles>
-            <PartitionState kxe="false" kb="ROO">running</PartitionState>
+            <PartitionState kxe="false" kb="ROO">not activated</PartitionState>
             <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
             <PartitionUUID kxe="false" kb="ROO">51B91FAB-1C58-4B9C-B239-878C01D5089C</PartitionUUID>
             <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
             <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
             <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
             <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">none</ResourceMonitoringControlState>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
             <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
             <ClientNetworkAdapters kxe="false" kb="CUR">
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter/246855ec-9d32-38af-aca5-644c04cdae95" rel="related"/>
@@ -2876,8 +2794,10 @@ http_interactions:
             </HostEthernetAdapterLogicalPorts>
             <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
-            <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
+            <ReferenceCode kb="ROO" kxe="true">00000000</ReferenceCode>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Valid</MigrationStorageViosDataStatus>
+            <MigrationStorageViosDataTimestamp ksv="V1_3_0" kb="ROR" kxe="false">Mon Nov 07 11:10:05 CET 2022</MigrationStorageViosDataTimestamp>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
             <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
             <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
@@ -2892,7 +2812,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:12 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0?group=None
@@ -2904,8 +2824,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -2915,27 +2834,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673537
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-682811673"
+      - "-1096403856"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - ad1854c3-de92-47b5-8df4-e8ace3f440e2
       Content-Length:
-      - '12863'
-      Set-Cookie:
-      - JSESSIONID=00003NUXdA9HzscOytwp_7PD1CI:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
+      - '12760'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -2945,19 +2853,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>1A5797C3-595D-4B52-A217-1C6A75B4F4C0</id>
             <title>LogicalPartition</title>
-            <published>2022-10-24T14:48:36.069+01:00</published>
+            <published>2022-11-17T09:40:54.529+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-682811673</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1096403856</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                 <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>1A5797C3-595D-4B52-A217-1C6A75B4F4C0</AtomID>
-                    <AtomCreated>1665051510369</AtomCreated>
+                    <AtomCreated>1667813811316</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">false</AllowPerformanceDataCollection>
@@ -2974,17 +2882,16 @@ http_interactions:
             <IsVirtualTrustedPlatformModuleEnabled kb="UOD" kxe="false">false</IsVirtualTrustedPlatformModuleEnabled>
             <KeylockPosition kxe="false" kb="CUD">normal</KeylockPosition>
             <LogicalSerialNumber kxe="false" kb="ROR">214D29V9</LogicalSerialNumber>
-            <OperatingSystemVersion kb="ROR" kxe="false">AIX 7.3 7300-00-00-0000</OperatingSystemVersion>
+            <OperatingSystemVersion kb="ROR" kxe="false">Unknown</OperatingSystemVersion>
             <PartitionCapabilities kb="ROR" kxe="false" schemaVersion="V1_5_0">
                 <Metadata>
                     <Atom/>
                 </Metadata>
-                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">true</DynamicLogicalPartitionIOCapable>
-                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">true</DynamicLogicalPartitionMemoryCapable>
-                <DynamicLogicalPartitionVIOSCapable ksv="V1_5_0" kxe="false" kb="ROR">false</DynamicLogicalPartitionVIOSCapable>
-                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">true</DynamicLogicalPartitionProcessorCapable>
-                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">true</InternalAndExternalIntrusionDetectionCapable>
-                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">true</ResourceMonitoringControlOperatingSystemShutdownCapable>
+                <DynamicLogicalPartitionIOCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionIOCapable>
+                <DynamicLogicalPartitionMemoryCapable kb="ROR" kxe="false">false</DynamicLogicalPartitionMemoryCapable>
+                <DynamicLogicalPartitionProcessorCapable kxe="false" kb="ROR">false</DynamicLogicalPartitionProcessorCapable>
+                <InternalAndExternalIntrusionDetectionCapable kb="CUD" kxe="false">false</InternalAndExternalIntrusionDetectionCapable>
+                <ResourceMonitoringControlOperatingSystemShutdownCapable kxe="false" kb="CUD">false</ResourceMonitoringControlOperatingSystemShutdownCapable>
             </PartitionCapabilities>
             <PartitionID kxe="false" kb="COD">9</PartitionID>
             <PartitionIOConfiguration kb="CUD" kxe="false" schemaVersion="V1_5_0">
@@ -3026,7 +2933,7 @@ http_interactions:
                 <MemoryExpansionEnabled kb="ROR" kxe="false">false</MemoryExpansionEnabled>
                 <RedundantErrorPathReportingEnabled kb="ROR" kxe="false">false</RedundantErrorPathReportingEnabled>
                 <RuntimeHugePageCount kb="ROR" kxe="false">0</RuntimeHugePageCount>
-                <RuntimeMemory kxe="false" kb="ROR">6144</RuntimeMemory>
+                <RuntimeMemory kxe="false" kb="ROR">256</RuntimeMemory>
                 <RuntimeMinimumMemory kxe="false" kb="ROR">4096</RuntimeMinimumMemory>
                 <SharedMemoryEnabled kb="CUD" kxe="false">false</SharedMemoryEnabled>
             </PartitionMemoryConfiguration>
@@ -3065,21 +2972,21 @@ http_interactions:
                     <CurrentUncappedWeight kxe="false" kb="ROR">128</CurrentUncappedWeight>
                     <CurrentMinimumVirtualProcessors kxe="false" kb="ROR">1</CurrentMinimumVirtualProcessors>
                     <CurrentMaximumVirtualProcessors kxe="false" kb="ROR">4</CurrentMaximumVirtualProcessors>
-                    <RuntimeProcessingUnits kxe="false" kb="ROR">1</RuntimeProcessingUnits>
-                    <RuntimeUncappedWeight kb="ROR" kxe="false">128</RuntimeUncappedWeight>
+                    <RuntimeProcessingUnits kxe="false" kb="ROR">0</RuntimeProcessingUnits>
+                    <RuntimeUncappedWeight kb="ROR" kxe="false">0</RuntimeUncappedWeight>
                 </CurrentSharedProcessorConfiguration>
             </PartitionProcessorConfiguration>
             <PartitionProfiles kxe="false" kb="CUD">
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/LogicalPartitionProfile/e7223768-1275-33da-83ad-4c73568363b9" rel="related"/>
             </PartitionProfiles>
-            <PartitionState kxe="false" kb="ROO">running</PartitionState>
+            <PartitionState kxe="false" kb="ROO">not activated</PartitionState>
             <PartitionType kb="COD" kxe="false">AIX/Linux</PartitionType>
             <PartitionUUID kxe="false" kb="ROO">1A5797C3-595D-4B52-A217-1C6A75B4F4C0</PartitionUUID>
             <PendingProcessorCompatibilityMode kb="CUD" kxe="false">default</PendingProcessorCompatibilityMode>
             <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
             <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
             <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">active</ResourceMonitoringControlState>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
             <ResourceMonitoringIPAddress kb="CUD" kxe="false">10.197.64.53</ResourceMonitoringIPAddress>
             <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
             <ClientNetworkAdapters kxe="false" kb="CUR">
@@ -3092,7 +2999,7 @@ http_interactions:
             </HostEthernetAdapterLogicalPorts>
             <IsServicePartition kxe="false" kb="CUD">false</IsServicePartition>
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
-            <ReferenceCode kb="ROO" kxe="true"/>
+            <ReferenceCode kb="ROO" kxe="true">00000000</ReferenceCode>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
             <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">No_Data</MigrationStorageViosDataStatus>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
@@ -3113,7 +3020,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:12 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC?group=None
@@ -3125,8 +3032,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3136,27 +3042,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673538
       Content-Type:
       - application/atom+xml
       Etag:
-      - "-1293817829"
+      - "-1552551999"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - d2d6421a-bb57-44d5-ba3a-9338f1829f8d
       Content-Length:
-      - '12056'
-      Set-Cookie:
-      - JSESSIONID=0000o4Gv-LnSGAKoFWa5_a97No8:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
+      - '12307'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3166,19 +3061,19 @@ http_interactions:
         <entry xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>29368E9C-E187-435C-8BA7-43770478B9BC</id>
             <title>LogicalPartition</title>
-            <published>2022-10-24T14:48:36.247+01:00</published>
+            <published>2022-11-17T09:40:54.700+01:00</published>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC?group=None"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <author>
                 <name>IBM Power Systems Management Console</name>
             </author>
-            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1293817829</etag:etag>
+            <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1552551999</etag:etag>
             <content type="application/vnd.ibm.powervm.uom+xml; type=LogicalPartition">
                 <LogicalPartition:LogicalPartition xmlns:LogicalPartition="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_5_0">
             <Metadata>
                 <Atom>
                     <AtomID>29368E9C-E187-435C-8BA7-43770478B9BC</AtomID>
-                    <AtomCreated>1665051509744</AtomCreated>
+                    <AtomCreated>1667813811298</AtomCreated>
                 </Atom>
             </Metadata>
             <AllowPerformanceDataCollection kxe="false" kb="CUD">true</AllowPerformanceDataCollection>
@@ -3299,7 +3194,7 @@ http_interactions:
             <ProcessorPool kb="CUD" kxe="false" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/SharedProcessorPool/945546e6-e848-3234-861c-72b861209d8f" rel="related"/>
             <ProgressPartitionDataRemaining kb="ROR" kxe="false">0</ProgressPartitionDataRemaining>
             <ProgressPartitionDataTotal kb="ROR" kxe="false">0</ProgressPartitionDataTotal>
-            <ResourceMonitoringControlState kxe="false" kb="ROR">none</ResourceMonitoringControlState>
+            <ResourceMonitoringControlState kxe="false" kb="ROR">inactive</ResourceMonitoringControlState>
             <AssociatedManagedSystem kxe="false" kb="CUD" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49" rel="related"/>
             <ClientNetworkAdapters kxe="false" kb="CUR">
                 <link href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter/81be3e5e-f516-37d1-8737-e5f57c7f93d7" rel="related"/>
@@ -3313,6 +3208,8 @@ http_interactions:
             <PowerVMManagementCapable ksv="V1_5_0" kb="ROR" kxe="false">false</PowerVMManagementCapable>
             <ReferenceCode kb="ROO" kxe="true">Linux ppc64le</ReferenceCode>
             <PowerOnWithHypervisor ksv="V1_2_0" kxe="false" kb="CUD">false</PowerOnWithHypervisor>
+            <MigrationStorageViosDataStatus ksv="V1_3_0" kb="ROR" kxe="false">Valid</MigrationStorageViosDataStatus>
+            <MigrationStorageViosDataTimestamp ksv="V1_3_0" kb="ROR" kxe="false">Mon Nov 07 11:10:04 CET 2022</MigrationStorageViosDataTimestamp>
             <RemoteRestartCapable kxe="false" kb="CUA">false</RemoteRestartCapable>
             <SimplifiedRemoteRestartCapable ksv="V1_2_0" kb="CUD" kxe="false">false</SimplifiedRemoteRestartCapable>
             <HasDedicatedProcessorsForMigration kxe="false" kb="ROR">false</HasDedicatedProcessorsForMigration>
@@ -3327,7 +3224,7 @@ http_interactions:
             </content>
         </entry>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:38 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter
@@ -3339,8 +3236,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3350,27 +3246,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673539
       Content-Type:
       - application/atom+xml
       Etag:
       - "-334069196"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 512cb12d-c0a1-4bb0-a761-8e6685fa01cc
       Content-Length:
       - '3368'
-      Set-Cookie:
-      - JSESSIONID=0000tF9mp5wou8Zd9h-oAFJ-AE_:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:35 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3379,14 +3264,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>73b49412-0de4-3ecc-9294-d9bb75a214d5</id>
-            <updated>2022-10-24T14:48:36.333+01:00</updated>
+            <updated>2022-11-17T09:40:54.801+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>56639748-8ecc-3726-811e-59b4e173e28d</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-10-24T14:48:36.354+01:00</published>
+                <published>2022-11-17T09:40:54.821+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/ClientNetworkAdapter/56639748-8ecc-3726-811e-59b4e173e28d"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3397,7 +3282,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>56639748-8ecc-3726-811e-59b4e173e28d</AtomID>
-                    <AtomCreated>1666528340049</AtomCreated>
+                    <AtomCreated>1668431880650</AtomCreated>
                 </Atom>
             </Metadata>
             <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V22-C2</DynamicReconfigurationConnectorName>
@@ -3424,7 +3309,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/ClientNetworkAdapter
@@ -3436,8 +3321,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3447,27 +3331,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673540
       Content-Type:
       - application/atom+xml
       Etag:
       - '649462617'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - dc0c93f4-2311-4b9e-af59-247ebb960d1e
       Content-Length:
       - '3289'
-      Set-Cookie:
-      - JSESSIONID=0000fvkMjXJWs2-GY9vo0QF_LKf:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3476,14 +3349,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>6235d777-99d2-3122-bca6-f4c7f7201d60</id>
-            <updated>2022-10-24T14:48:36.405+01:00</updated>
+            <updated>2022-11-17T09:40:54.878+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>70f053eb-39f6-3c5d-b2e2-4237990de986</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-10-24T14:48:36.425+01:00</published>
+                <published>2022-11-17T09:40:54.899+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/ClientNetworkAdapter/70f053eb-39f6-3c5d-b2e2-4237990de986"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3494,7 +3367,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>70f053eb-39f6-3c5d-b2e2-4237990de986</AtomID>
-                    <AtomCreated>1666528340304</AtomCreated>
+                    <AtomCreated>1668431880875</AtomCreated>
                 </Atom>
             </Metadata>
             <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V18-C3</DynamicReconfigurationConnectorName>
@@ -3520,7 +3393,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter
@@ -3532,8 +3405,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3543,27 +3415,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673541
       Content-Type:
       - application/atom+xml
       Etag:
       - "-924072795"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - d2de28f1-7c65-484d-80c8-132c580f6667
       Content-Length:
-      - '3289'
-      Set-Cookie:
-      - JSESSIONID=00007opAUyJ4RG_TD17_4amQRFt:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
+      - '3290'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3572,14 +3433,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>c3170c58-b788-3572-8f33-4e7e86eaf3cb</id>
-            <updated>2022-10-24T14:48:36.478+01:00</updated>
+            <updated>2022-11-17T09:40:54.946+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>246855ec-9d32-38af-aca5-644c04cdae95</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-10-24T14:48:36.499+01:00</published>
+                <published>2022-11-17T09:40:54.982+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/ClientNetworkAdapter/246855ec-9d32-38af-aca5-644c04cdae95"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3590,14 +3451,14 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>246855ec-9d32-38af-aca5-644c04cdae95</AtomID>
-                    <AtomCreated>1666528340233</AtomCreated>
+                    <AtomCreated>1668431880803</AtomCreated>
                 </Atom>
             </Metadata>
             <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V19-C2</DynamicReconfigurationConnectorName>
             <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V19-C2</LocationCode>
             <LocalPartitionID kxe="false" kb="CUR">19</LocalPartitionID>
             <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VariedOn kxe="true" kb="CUD">false</VariedOn>
             <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
             <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
             <MACAddress kxe="false" kb="CUR">22ED8A9E4B02</MACAddress>
@@ -3616,7 +3477,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/ClientNetworkAdapter
@@ -3628,8 +3489,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3639,27 +3499,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673543
       Content-Type:
       - application/atom+xml
       Etag:
       - '1179222038'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - f4a6981f-0cda-4869-92b3-232145ec9567
       Content-Length:
-      - '3285'
-      Set-Cookie:
-      - JSESSIONID=0000iOzW7G4dMojzF0v_ak-B8gJ:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
+      - '3286'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3668,14 +3517,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>89104412-efce-3857-9796-4545310edd09</id>
-            <updated>2022-10-24T14:48:36.548+01:00</updated>
+            <updated>2022-11-17T09:40:55.031+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>8fa4f3d2-92c8-3b2c-a113-106a1cb79a81</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-10-24T14:48:36.569+01:00</published>
+                <published>2022-11-17T09:40:55.052+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/ClientNetworkAdapter/8fa4f3d2-92c8-3b2c-a113-106a1cb79a81"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3686,14 +3535,14 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>8fa4f3d2-92c8-3b2c-a113-106a1cb79a81</AtomID>
-                    <AtomCreated>1666528340943</AtomCreated>
+                    <AtomCreated>1668431881609</AtomCreated>
                 </Atom>
             </Metadata>
             <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V9-C2</DynamicReconfigurationConnectorName>
             <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V9-C2</LocationCode>
             <LocalPartitionID kxe="false" kb="CUR">9</LocalPartitionID>
             <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VariedOn kxe="true" kb="CUD">false</VariedOn>
             <VirtualSlotNumber kb="COD" kxe="false">2</VirtualSlotNumber>
             <AllowedOperatingSystemMACAddresses kxe="false" kb="CUD">ALL</AllowedOperatingSystemMACAddresses>
             <MACAddress kxe="false" kb="CUR">22ED8B83B802</MACAddress>
@@ -3712,7 +3561,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter
@@ -3724,8 +3573,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3735,27 +3583,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673544
       Content-Type:
       - application/atom+xml
       Etag:
       - '179491665'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 05c52c61-bd3d-4071-82b0-f4b585576689
       Content-Length:
       - '3287'
-      Set-Cookie:
-      - JSESSIONID=0000Tc1MtNvNdXc1OI-8nQD4Qog:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3764,14 +3601,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>8af8e120-8c21-3028-872e-fed5d6ccb149</id>
-            <updated>2022-10-24T14:48:36.620+01:00</updated>
+            <updated>2022-11-17T09:40:55.101+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>81be3e5e-f516-37d1-8737-e5f57c7f93d7</id>
                 <title>ClientNetworkAdapter</title>
-                <published>2022-10-24T14:48:36.642+01:00</published>
+                <published>2022-11-17T09:40:55.122+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/ClientNetworkAdapter/81be3e5e-f516-37d1-8737-e5f57c7f93d7"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3782,7 +3619,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>81be3e5e-f516-37d1-8737-e5f57c7f93d7</AtomID>
-                    <AtomCreated>1666528340376</AtomCreated>
+                    <AtomCreated>1668431880944</AtomCreated>
                 </Atom>
             </Metadata>
             <DynamicReconfigurationConnectorName kb="CUD" kxe="false">U8286.42A.214D29V-V17-C2</DynamicReconfigurationConnectorName>
@@ -3808,7 +3645,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/VirtualSCSIClientAdapter
@@ -3820,8 +3657,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3831,27 +3667,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673545
       Content-Type:
       - application/atom+xml
       Etag:
       - '1534883596'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 3fd47199-510a-46f1-be6f-3ba10e05e32c
       Content-Length:
       - '3818'
-      Set-Cookie:
-      - JSESSIONID=0000DSCsaDFGdIa9loRHLtTjfiK:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3860,14 +3685,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>0f2fd7b5-3011-37db-a26f-071602798abd</id>
-            <updated>2022-10-24T14:48:36.908+01:00</updated>
+            <updated>2022-11-17T09:40:55.367+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/VirtualSCSIClientAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>b62db2fa-d7e6-37c4-8a0c-acb10d0b24c6</id>
                 <title>VirtualSCSIClientAdapter</title>
-                <published>2022-10-24T14:48:36.927+01:00</published>
+                <published>2022-11-17T09:40:55.386+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/4636108C-4424-4490-808A-9C6764F2B874/VirtualSCSIClientAdapter/b62db2fa-d7e6-37c4-8a0c-acb10d0b24c6"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3878,7 +3703,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>b62db2fa-d7e6-37c4-8a0c-acb10d0b24c6</AtomID>
-                    <AtomCreated>1666619316921</AtomCreated>
+                    <AtomCreated>1668674055880</AtomCreated>
                 </Atom>
             </Metadata>
             <AdapterType kb="ROR" kxe="false">Client</AdapterType>
@@ -3912,7 +3737,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/VirtualSCSIClientAdapter
@@ -3924,8 +3749,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -3935,27 +3759,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673546
       Content-Type:
       - application/atom+xml
       Etag:
       - '1000703445'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - e03e3ce8-c007-4588-8c13-de2098e26474
       Content-Length:
       - '3819'
-      Set-Cookie:
-      - JSESSIONID=0000lcJmb2aQCO3yuMALc7LzRoR:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -3964,14 +3777,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>69edf663-e12a-3e7c-ad86-d626803f9053</id>
-            <updated>2022-10-24T14:48:36.977+01:00</updated>
+            <updated>2022-11-17T09:40:55.433+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/VirtualSCSIClientAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>ce95dcfc-1ecb-3e50-9e72-eb2c7c235ad1</id>
                 <title>VirtualSCSIClientAdapter</title>
-                <published>2022-10-24T14:48:36.995+01:00</published>
+                <published>2022-11-17T09:40:55.451+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/7F840DA7-9563-40B0-B913-DDDF3368BCEE/VirtualSCSIClientAdapter/ce95dcfc-1ecb-3e50-9e72-eb2c7c235ad1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -3982,7 +3795,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>ce95dcfc-1ecb-3e50-9e72-eb2c7c235ad1</AtomID>
-                    <AtomCreated>1666619316989</AtomCreated>
+                    <AtomCreated>1668674056028</AtomCreated>
                 </Atom>
             </Metadata>
             <AdapterType kb="ROR" kxe="false">Client</AdapterType>
@@ -4016,7 +3829,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/VirtualSCSIClientAdapter
@@ -4028,8 +3841,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -4039,27 +3851,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673547
       Content-Type:
       - application/atom+xml
       Etag:
       - '529767456'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:37 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - e4d14ef9-37e4-45a0-bc69-d7a3005c7e44
       Content-Length:
-      - '3817'
-      Set-Cookie:
-      - JSESSIONID=0000zd3TvOb3ylVh9hJ27DTLyXg:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:36 GMT
+      - '3818'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -4068,14 +3869,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>25787342-ddb3-3fba-b7de-8f9aa421bc01</id>
-            <updated>2022-10-24T14:48:37.048+01:00</updated>
+            <updated>2022-11-17T09:40:55.500+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/VirtualSCSIClientAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>fd2f524f-1408-301f-bbb0-771904a4fde1</id>
                 <title>VirtualSCSIClientAdapter</title>
-                <published>2022-10-24T14:48:37.067+01:00</published>
+                <published>2022-11-17T09:40:55.518+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/51B91FAB-1C58-4B9C-B239-878C01D5089C/VirtualSCSIClientAdapter/fd2f524f-1408-301f-bbb0-771904a4fde1"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -4086,7 +3887,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>fd2f524f-1408-301f-bbb0-771904a4fde1</AtomID>
-                    <AtomCreated>1666619317061</AtomCreated>
+                    <AtomCreated>1668674056096</AtomCreated>
                 </Atom>
             </Metadata>
             <AdapterType kb="ROR" kxe="false">Client</AdapterType>
@@ -4094,7 +3895,7 @@ http_interactions:
             <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V19-C3</LocationCode>
             <LocalPartitionID kxe="false" kb="CUR">19</LocalPartitionID>
             <RequiredAdapter kb="CUD" kxe="false">false</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VariedOn kxe="true" kb="CUD">false</VariedOn>
             <VirtualSlotNumber kb="COD" kxe="false">3</VirtualSlotNumber>
             <RemoteLogicalPartitionID kxe="false" kb="CUR">1</RemoteLogicalPartitionID>
             <RemoteSlotNumber kxe="false" kb="CUA">38</RemoteSlotNumber>
@@ -4120,7 +3921,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/VirtualSCSIClientAdapter
@@ -4132,8 +3933,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -4143,27 +3943,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673548
       Content-Type:
       - application/atom+xml
       Etag:
       - "-1832517367"
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:37 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 967c02d3-4aa6-4d16-afe6-f21b396a9753
       Content-Length:
-      - '3808'
-      Set-Cookie:
-      - JSESSIONID=0000YcXI_g4_kR3rMcXkDfHekUm:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:37 GMT
+      - '3809'
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -4172,14 +3961,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>bbd8ed0a-5619-3532-a70c-29350b1d4756</id>
-            <updated>2022-10-24T14:48:37.119+01:00</updated>
+            <updated>2022-11-17T09:40:55.568+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/VirtualSCSIClientAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>6da40781-1389-38c0-ab6f-fd52dfa9117a</id>
                 <title>VirtualSCSIClientAdapter</title>
-                <published>2022-10-24T14:48:37.138+01:00</published>
+                <published>2022-11-17T09:40:55.587+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/1A5797C3-595D-4B52-A217-1C6A75B4F4C0/VirtualSCSIClientAdapter/6da40781-1389-38c0-ab6f-fd52dfa9117a"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -4190,7 +3979,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>6da40781-1389-38c0-ab6f-fd52dfa9117a</AtomID>
-                    <AtomCreated>1666619317132</AtomCreated>
+                    <AtomCreated>1668674056168</AtomCreated>
                 </Atom>
             </Metadata>
             <AdapterType kb="ROR" kxe="false">Client</AdapterType>
@@ -4198,7 +3987,7 @@ http_interactions:
             <LocationCode kxe="false" kb="ROR">U8286.42A.214D29V-V9-C4</LocationCode>
             <LocalPartitionID kxe="false" kb="CUR">9</LocalPartitionID>
             <RequiredAdapter kb="CUD" kxe="false">true</RequiredAdapter>
-            <VariedOn kxe="true" kb="CUD">true</VariedOn>
+            <VariedOn kxe="true" kb="CUD">false</VariedOn>
             <VirtualSlotNumber kb="COD" kxe="false">4</VirtualSlotNumber>
             <RemoteLogicalPartitionID kxe="false" kb="CUR">1</RemoteLogicalPartitionID>
             <RemoteSlotNumber kxe="false" kb="CUA">5</RemoteSlotNumber>
@@ -4224,7 +4013,7 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
 - request:
     method: get
     uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/VirtualSCSIClientAdapter
@@ -4236,8 +4025,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -4247,27 +4035,16 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673549
       Content-Type:
       - application/atom+xml
       Etag:
       - '1147670920'
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
-      Last-Modified:
-      - Mon, 24 Oct 2022 13:48:37 GMT
       X-Hmc-Schema-Version:
       - V1_5_0
-      X-Transactionrecord-Uuid:
-      - 975aa47c-c5f4-458e-a71e-176aaa42b678
       Content-Length:
       - '3817'
-      Set-Cookie:
-      - JSESSIONID=0000l4xfTPBZnIk-1nTD1ZKlhbK:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      Date:
-      - Mon, 24 Oct 2022 13:48:37 GMT
       Cache-Control:
       - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
     body:
@@ -4276,14 +4053,14 @@ http_interactions:
 
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
             <id>ed484f7c-fb94-345d-a7a2-67fcd22aafb8</id>
-            <updated>2022-10-24T14:48:37.198+01:00</updated>
+            <updated>2022-11-17T09:40:55.632+01:00</updated>
             <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/VirtualSCSIClientAdapter"/>
             <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
             <generator>IBM Power Systems Management Console</generator>
             <entry>
                 <id>4ad1d348-c6df-39f6-8126-e6211548046e</id>
                 <title>VirtualSCSIClientAdapter</title>
-                <published>2022-10-24T14:48:37.217+01:00</published>
+                <published>2022-11-17T09:40:55.649+01:00</published>
                 <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/LogicalPartition/29368E9C-E187-435C-8BA7-43770478B9BC/VirtualSCSIClientAdapter/4ad1d348-c6df-39f6-8126-e6211548046e"/>
                 <author>
                     <name>IBM Power Systems Management Console</name>
@@ -4294,7 +4071,7 @@ http_interactions:
             <Metadata>
                 <Atom>
                     <AtomID>4ad1d348-c6df-39f6-8126-e6211548046e</AtomID>
-                    <AtomCreated>1666619317211</AtomCreated>
+                    <AtomCreated>1668674056235</AtomCreated>
                 </Atom>
             </Metadata>
             <AdapterType kb="ROR" kxe="false">Client</AdapterType>
@@ -4328,7 +4105,116 @@ http_interactions:
             </entry>
         </feed>
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:13 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:39 GMT
+- request:
+    method: get
+    uri: https://ibm-power-hmc-hostname:12443/rest/api/uom/Group
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
+      X-Api-Session: xxx
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Servlet/3.0
+      Content-Type:
+      - application/atom+xml
+      Etag:
+      - "-1146424212"
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Hmc-Schema-Version:
+      - V1_5_0
+      Content-Length:
+      - '4659'
+      Cache-Control:
+      - no-transform, must-revalidate, proxy-revalidate, no-cache=set-cookie
+    body:
+      encoding: UTF-8
+      string: |2
+
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ns2="http://a9.com/-/spec/opensearch/1.1/" xmlns:ns3="http://www.w3.org/1999/xhtml">
+            <id>3d9231ee-e5bc-38e7-b59c-00f9a1384022</id>
+            <updated>2022-11-17T09:40:55.739+01:00</updated>
+            <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group"/>
+            <link rel="MANAGEMENT_CONSOLE" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e"/>
+            <generator>IBM Power Systems Management Console</generator>
+            <entry>
+                <id>24f0e0fe-7879-4050-be45-a6e76426423d</id>
+                <title>Group</title>
+                <published>2022-11-17T09:40:55.741+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group/24f0e0fe-7879-4050-be45-a6e76426423d"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-1676141590</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=Group">
+                    <Group:Group xmlns:Group="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_2_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>24f0e0fe-7879-4050-be45-a6e76426423d</AtomID>
+                    <AtomCreated>1668674455740</AtomCreated>
+                </Atom>
+            </Metadata>
+            <GroupUUID ksv="V1_2_0" kb="ROR" kxe="false">24f0e0fe-7879-4050-be45-a6e76426423d</GroupUUID>
+            <GroupName ksv="V1_2_0" kb="COR" kxe="false">mon_groupe</GroupName>
+            <GroupDescription ksv="V1_2_0" kxe="false" kb="COR"/>
+            <GroupColor ksv="V1_2_0" kb="COR" kxe="false">Grey</GroupColor>
+            <AssociatedLogicalPartitions ksv="V1_2_0" kb="COD" kxe="false">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/256B63BC-868F-4CB8-AB00-94387264B66A" rel="related"/>
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/LogicalPartition/00000000-0000-0000-0000-000000000000" rel="related"/>
+            </AssociatedLogicalPartitions>
+            <AssociatedVirtualIOServers ksv="V1_2_0" kxe="false" kb="COD">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/VirtualIOServer/722B9A3A-15DC-4BE1-AAFE-ED5D17C70371" rel="related"/>
+            </AssociatedVirtualIOServers>
+            <AssociatedManagedSystems ksv="V1_2_0" kb="COD" kxe="false"/>
+        </Group:Group>
+                </content>
+            </entry>
+            <entry>
+                <id>73254f6f-5977-4642-92cd-3cdc8a0632a0</id>
+                <title>Group</title>
+                <published>2022-11-17T09:40:55.742+01:00</published>
+                <link rel="SELF" href="https://ibm-power-hmc-hostname:12443/rest/api/uom/Group/73254f6f-5977-4642-92cd-3cdc8a0632a0"/>
+                <author>
+                    <name>IBM Power Systems Management Console</name>
+                </author>
+                <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-725643435</etag:etag>
+                <content type="application/vnd.ibm.powervm.uom+xml; type=Group">
+                    <Group:Group xmlns:Group="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_2_0">
+            <Metadata>
+                <Atom>
+                    <AtomID>73254f6f-5977-4642-92cd-3cdc8a0632a0</AtomID>
+                    <AtomCreated>1668674455740</AtomCreated>
+                </Atom>
+            </Metadata>
+            <GroupUUID ksv="V1_2_0" kb="ROR" kxe="false">73254f6f-5977-4642-92cd-3cdc8a0632a0</GroupUUID>
+            <GroupName ksv="V1_2_0" kb="COR" kxe="false">ManageIQ</GroupName>
+            <GroupDescription ksv="V1_2_0" kxe="false" kb="COR"/>
+            <GroupColor ksv="V1_2_0" kb="COR" kxe="false">Orange</GroupColor>
+            <AssociatedLogicalPartitions ksv="V1_2_0" kb="COD" kxe="false">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/ManagedSystem/0685d4a6-2021-3044-84e3-59f44e9cc5d7/LogicalPartition/646AE0BC-CF06-4F6B-83CB-7A3ECCF903E3" rel="related"/>
+            </AssociatedLogicalPartitions>
+            <AssociatedVirtualIOServers ksv="V1_2_0" kxe="false" kb="COD">
+                <link href="https://ibm-power-hmc-hostname/rest/api/uom/VirtualIOServer/4165A16F-0766-40F3-B9E2-7272E1910F2E" rel="related"/>
+            </AssociatedVirtualIOServers>
+            <AssociatedManagedSystems ksv="V1_2_0" kb="COD" kxe="false"/>
+        </Group:Group>
+                </content>
+            </entry>
+        </feed>
+    http_version:
+  recorded_at: Thu, 17 Nov 2022 08:09:40 GMT
 - request:
     method: delete
     uri: https://ibm-power-hmc-hostname:12443/rest/api/web/Logon
@@ -4340,8 +4226,7 @@ http_interactions:
       - "*/*"
       User-Agent:
       - rest-client/2.1.0 (linux-gnu powerpc64le) ruby/2.7.2p137
-      X-Api-Session:
-      - NQRhXlVLNA-LHjCKlHePedfCvv1MuN4BH1aJiiRWZaA_ZH-JdDloG5iHhQ-poggAIOVceq8moyuRobsvXAp9D4xmUV_6TbLz0C4KonS964Wv1EQI0K9OEC6mnV4eHqmpdTzoSm_9KvQd58l_tuSje237ooQFW1NtsflAH2TJbci3xOj4WTRQmNyXjMkv5dl8Uvwfl2FRNaIkN3lEs23UP3N7JhHdwGXLohDrm9esKaU=
+      X-Api-Session: xxx
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -4351,21 +4236,10 @@ http_interactions:
     headers:
       X-Powered-By:
       - Servlet/3.0
-      X-Transaction-Id:
-      - XT12673550
       Content-Language:
       - en-US
       Content-Length:
       - '0'
-      Set-Cookie:
-      - CCFWSESSION=AB0D1B044746B0DDC8A157C5D6245C29; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/"; Secure
-      - JSESSIONID=0000SqhyREnewp_-Ad1O90LuIL9:8c7885c5-2b0c-4564-8d2d-59c6417de7a1;
-        Path=/; Secure; HttpOnly
-      - JSESSIONID=AB0D1B044746B0DDC8A157C5D6245C29; Version=1; Domain=coophmc2.coopibm.frec.bull.fr;
-        Max-Age=0; Path="/hmc"; Secure
-      Date:
-      - Mon, 24 Oct 2022 13:48:37 GMT
       Expires:
       - Thu, 01 Dec 1994 16:00:00 GMT
       Cache-Control:
@@ -4374,5 +4248,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Mon, 24 Oct 2022 13:17:14 GMT
+  recorded_at: Thu, 17 Nov 2022 08:09:40 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
The HMC allows the creation of what it calls "groups" which are basically just labels for LPARs, VIOSes and managed systems.
An LPAR, a VIOS or a managed system can be part of several groups at the same time.
Groups have a description and a color assigned to them.

LPAR view:
![image](https://user-images.githubusercontent.com/48122102/200596746-6ab7a55e-251e-4b4f-8cd2-73a6795f62ba.png)

Groups view:
![image](https://user-images.githubusercontent.com/48122102/200596478-ffbcdbf4-bce3-45e6-aff5-f8fd5b311151.png)

With these changes, labels appear in MIQ UI like so:
![image](https://user-images.githubusercontent.com/48122102/200596979-b3f01e8c-7383-46b6-b7df-b2e860173498.png)
