### PR TITLE
Errors in log due to some HMC Usertask events not handled properly

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -78,6 +78,8 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
       else
         []
       end
+    else
+      []
     end
   end
 

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -67,17 +67,15 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
   end
 
   def handle_usertask(usertask)
-    if usertask["status"].eql?("Completed")
-      case usertask["key"]
-      when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_PARTITION_SAVE_AS", "TEMPLATE_PARTITION_CAPTURE"
-        handle_usertask_template_save(usertask)
-      when "TEMPLATE_DELETE"
-        handle_usertask_template_delete(usertask)
-      when "PCM_PREFERENCE_UPDATE"
-        handle_usertask_pcm_preference(usertask)
-      else
-        []
-      end
+    return [] unless usertask["status"].eql?("Completed")
+
+    case usertask["key"]
+    when "TEMPLATE_PARTITION_SAVE", "TEMPLATE_PARTITION_SAVE_AS", "TEMPLATE_PARTITION_CAPTURE"
+      handle_usertask_template_save(usertask)
+    when "TEMPLATE_DELETE"
+      handle_usertask_template_delete(usertask)
+    when "PCM_PREFERENCE_UPDATE"
+      handle_usertask_pcm_preference(usertask)
     else
       []
     end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -118,14 +118,49 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
     end
   end
 
+  context "Ignored Usertasks" do
+    it "Ignored key" do
+      assert_event_triggers_target("test_data/ignored_usertask.xml", nil,
+        {
+          "uuid"           => "58ad2817-3365-4de4-a9fe-f0a587bfc326",
+          "key"            => "CCFW_POOL_MANAGEMENT_TASK",
+          "localizedLabel" => "Shared memory pool",
+          "labelParams"    => ["system 2022/11/07 08:44:10.022", "id 62"],
+          "initiator"      => "hscroot",
+          "timeStarted"    => 1_668_072_627_838,
+          "timeCompleted"  => 1_668_072_632_703,
+          "status"         => "Completed",
+          "visible"        => true
+        }
+      )
+    end
+    it "Running UserTask" do
+      assert_event_triggers_target("test_data/pcm_preferences.xml", nil,
+        {
+          "uuid"           => "99630d72-36b7-4fa6-8307-b70aef13b0b0",
+          "key"            => "PCM_PREFERENCE_UPDATE",
+          "localizedLabel" => "Update performance monitoring settings",
+          "labelParams"    => ["[aramis, porthos]"],
+          "initiator"      => "hscroot",
+          "timeStarted"    => 1_652_866_657_499,
+          "timeCompleted"  => 1_652_866_657_594,
+          "status"         => "Running",
+          "visible"        => true
+        }
+      )
+    end
+  end
+
   def assert_event_triggers_target(filename, expected_targets, usertask = nil)
     ems_event      = create_ems_event(filename, usertask)
     parsed_targets = described_class.new(ems_event).parse
 
-    expect(parsed_targets.size).to eq(expected_targets.count)
-    expect(target_references(parsed_targets)).to(
-      match_array(expected_targets)
-    )
+    aggregate_failures "expected_targets" do
+      expect(parsed_targets.size).to eq(expected_targets.count) unless expected_targets.nil?
+      expect(target_references(parsed_targets)).to(
+        match_array(expected_targets)
+      )
+    end
   end
 
   def target_references(parsed_targets)

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -120,7 +120,9 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
 
   context "Ignored Usertasks" do
     it "Ignored key" do
-      assert_event_triggers_target("test_data/ignored_usertask.xml", nil,
+      assert_event_triggers_target(
+        "test_data/ignored_usertask.xml",
+        nil,
         {
           "uuid"           => "58ad2817-3365-4de4-a9fe-f0a587bfc326",
           "key"            => "CCFW_POOL_MANAGEMENT_TASK",
@@ -135,7 +137,9 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
       )
     end
     it "Running UserTask" do
-      assert_event_triggers_target("test_data/pcm_preferences.xml", nil,
+      assert_event_triggers_target(
+        "test_data/pcm_preferences.xml",
+        nil,
         {
           "uuid"           => "99630d72-36b7-4fa6-8307-b70aef13b0b0",
           "key"            => "PCM_PREFERENCE_UPDATE",

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/ignored_usertask.xml
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/ignored_usertask.xml
@@ -1,0 +1,31 @@
+<feed xmlns:ns2='http://a9.com/-/spec/opensearch/1.1/' xmlns:ns3='http://www.w3.org/1999/xhtml' xmlns='http://www.w3.org/2005/Atom'>
+    <id>064240ce-c295-34cb-a0b5-8e6ee0e7a615</id>
+    <updated>2022-11-10T10:30:32.813+01:00</updated>
+    <link href='https://coophmc2:12443/rest/api/uom/Event' rel='SELF'/>
+    <link href='https://coophmc2:12443/rest/api/uom/ManagementConsole/67c67e9a-c027-3a3d-9399-ebe6aa14e12e' rel='MANAGEMENT_CONSOLE'/>
+    <generator>IBM Power Systems Management Console</generator>
+    <entry>
+        <id>fca978b5-2ad6-37f2-b949-599d3c9216f3</id>
+        <title>Event</title>
+        <published>2022-11-10T10:30:32.845+01:00</published>
+        <link href='https://coophmc2:12443/rest/api/uom/Event/fca978b5-2ad6-37f2-b949-599d3c9216f3' rel='SELF'/>
+        <author>
+            <name>IBM Power Systems Management Console</name>
+        </author>
+        <etag:etag xmlns:etag='http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/' xmlns='http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/'>-401492496</etag:etag>
+        <content type='application/vnd.ibm.powervm.uom+xml; type=Event'>
+            <Event:Event xmlns:Event='http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/' xmlns:ns2='http://www.w3.org/XML/1998/namespace/k2' schemaVersion='V1_5_0' xmlns='http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/'>
+    <Metadata>
+        <Atom>
+            <AtomID>fca978b5-2ad6-37f2-b949-599d3c9216f3</AtomID>
+            <AtomCreated>1668072632844</AtomCreated>
+        </Atom>
+    </Metadata>
+    <EventType kb='ROR' kxe='false'>MODIFY_URI</EventType>
+    <EventID kb='ROR' kxe='false'>1667807043265</EventID>
+    <EventData kb='ROR' kxe='false'>https://coophmc2:12443/rest/api/uom/UserTask/58ad2817-3365-4de4-a9fe-f0a587bfc326</EventData>
+    <EventDetail kb='ROR' kxe='false'>Other</EventDetail>
+</Event:Event>
+        </content>
+    </entry>
+</feed>


### PR DESCRIPTION
HMC events of type "UserTask" that have their status set to something other than "Completed" are causing are not handled well by the event target parser. This generate an error in evm.log like this one:

```
[----] E, [2022-11-09T14:39:47.411859 #218489:1705c] ERROR -- evm: MIQ(MiqAeEngine.deliver) Error delivering {:event_id=>369279, :event_stream_id=>369279, :event_type=>"ADD_URI", "User::user"=>1, "EventStream::event_stream"=>369279} for object [EmsEvent.369279] with state [] to Automate: no implicit conversion of nil into Array
```

Actual error is:
```
        2: from /home/padmin/manageiq-providers-ibm_power_hmc/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb:48:in `parse'
        1: from /home/padmin/manageiq-providers-ibm_power_hmc/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb:48:in `concat'
TypeError (no implicit conversion of nil into Array)
```

Fix event target parser to ignore these events and add specs.