### PR TITLE
add vm reconfiguration for cpu, memory and network

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -3,6 +3,10 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers
     unsupported_reason_add(:provisioning, _('Not connected to ems')) if ext_management_system.nil?
   end
 
+  supports :reconfigure_network_adapters do
+    unsupported_reason_add(:reconfigure_network_adapters, _("Host is not HMC-managed")) unless host_hmc_managed
+  end
+
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect
     connection.lpar(ems_ref)

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -3,9 +3,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers
     unsupported_reason_add(:provisioning, _('Not connected to ems')) if ext_management_system.nil?
   end
 
-  supports :reconfigure_network_adapters do
-    unsupported_reason_add(:reconfigure_network_adapters, _("Host is not HMC-managed")) unless host_hmc_managed
-  end
+  supports :reconfigure_network_adapters
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -48,9 +48,6 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
   end
 
   def raw_destroy
-    ext_management_system.with_provider_connection do |connection|
-      connection.lpar_delete(ems_ref)
-    end
   end
 
   def raw_suspend

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
@@ -53,19 +53,20 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm::Reconfigure
   end
 
   def build_proc_config_spec(lpar, spec, options)
+    if lpar.dedicated == "true"
+      min, max = lpar.minimum_procs, lpar.maximum_procs
+      attr = :desired_procs
+    else
+      min, max = lpar.minimum_vprocs, lpar.maximum_vprocs
+      attr = :desired_vprocs
+    end
+
     desired_procs = options[:number_of_cpus].to_i
 
-    if lpar.dedicated == "true"
-      raise MiqException::MiqVmError, "Processor count cannot be lower than #{lpar.minimum_procs}"   if desired_procs < lpar.minimum_procs.to_i
-      raise MiqException::MiqVmError, "Processor count cannot be greater than #{lpar.maximum_procs}" if desired_procs > lpar.maximum_procs.to_i
+    raise MiqException::MiqVmError, "Processor count cannot be lower than #{min}"   if desired_procs < min.to_i
+    raise MiqException::MiqVmError, "Processor count cannot be greater than #{max}" if desired_procs > max.to_i
 
-      spec[:desired_procs] = desired_procs
-    else
-      raise MiqException::MiqVmError, "Virtual processor count cannot be lower than #{lpar.minimum_vprocs}"   if desired_procs < lpar.minimum_vprocs.to_i
-      raise MiqException::MiqVmError, "Virtual processor count cannot be greater than #{lpar.maximum_vprocs}" if desired_procs > lpar.maximum_vprocs.to_i
-
-      spec[:desired_vprocs] = desired_procs
-    end
+    spec[attr] = desired_procs
   end
 
   def build_netadap_create_config_spec(spec, options)

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
@@ -22,60 +22,64 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm::Reconfigure
   def build_config_spec(options)
     $ibm_power_hmc_log.debug("building spec for #{options}")
 
-    spec = {}
-
     lpar = ext_management_system.with_provider_connection { |connection| provider_object(connection) }
 
     # Dynamic Reconfiguration requires RMC to be active.
     raise MiqException::MiqVmError, "RMC is not active on target" if lpar.state == "running" && lpar.rmc_state != "active"
 
-    if options.key?(:vm_memory)
-      desired_memory = options[:vm_memory].to_i
+    # HMC does not allow changing the VSWITCH or the VLAN of a client network adapter.
+    # It could be done by deleting and recreating the adapter with the same MAC and options.
+    raise MiqException::MiqVmError, "Cannot edit existing network adapter" if options.key?(:network_adapter_edit)
 
-      raise MiqException::MiqVmError, "Memory cannot be lower than #{lpar.min_memory} MB"   if desired_memory < lpar.min_memory.to_i
-      raise MiqException::MiqVmError, "Memory cannot be greater than #{lpar.max_memory} MB" if desired_memory > lpar.max_memory.to_i
-      spec[:desired_memory] = desired_memory
-    end
-
-    if options.key?(:number_of_cpus)
-      desired_vprocs = options[:number_of_cpus].to_i
-
-      raise MiqException::MiqVmError, "Virtual processor count cannot be lower than #{lpar.minimum_vprocs}"   if desired_vprocs < lpar.minimum_vprocs.to_i
-      raise MiqException::MiqVmError, "Virtual processor count cannot be greater than #{lpar.maximum_vprocs}" if desired_vprocs > lpar.maximum_vprocs.to_i
-      spec[:desired_vprocs] = desired_vprocs
-    end
-
-    if options.key?(:network_adapter_add)
-      spec[:netadap_create] = options[:network_adapter_add].map do |adapt|
-        # Retrieve LAN attributes from DB.
-        switch_ids = HostSwitch.where(:host_id => host.id).pluck(:switch_id)
-        lan = Lan.find_by(:name => adapt[:network], :switch_id => switch_ids)
-        raise MiqException::MiqVmError, "Network [#{adapt[:network]}] is not available on target" if lan.nil?
-
-        {
-          :sys_uuid     => host.ems_ref,
-          :vswitch_uuid => lan.switch.uid_ems,
-          :attrs        => {:vlan_id => lan.tag}
-        }
-      end
-    end
-
-    if options.key?(:network_adapter_edit)
-      # HMC does not allow changing the VSWITCH or the VLAN of a client network adapter.
-      # It would require to delete and recreate the adapter with the same MAC.
-      raise MiqException::MiqVmError, "Cannot edit existing network adapter"
-    end
-
-    if options.key?(:network_adapter_remove)
-      spec[:netadap_delete] = options[:network_adapter_remove].map do |adapt|
-        nic = nics.find_by(:address => adapt[:network][:mac])
-        raise MiqException::MiqVmError, "Network adapter [#{adapt[:network][:mac]}] is not available on target" if nic.nil?
-
-        nic.uid_ems
-      end
-    end
+    spec = {}
+    build_memory_config_spec(lpar, spec, options) if options.key?(:vm_memory)
+    build_vproc_config_spec(lpar, spec, options) if options.key?(:number_of_cpus)
+    build_netadap_create_config_spec(spec, options) if options.key?(:network_adapter_add)
+    build_netadap_delete_config_spec(spec, options) if options.key?(:network_adapter_remove)
 
     spec
+  end
+
+  def build_memory_config_spec(lpar, spec, options)
+    desired_memory = options[:vm_memory].to_i
+
+    raise MiqException::MiqVmError, "Memory cannot be lower than #{lpar.min_memory} MB"   if desired_memory < lpar.min_memory.to_i
+    raise MiqException::MiqVmError, "Memory cannot be greater than #{lpar.max_memory} MB" if desired_memory > lpar.max_memory.to_i
+
+    spec[:desired_memory] = desired_memory
+  end
+
+  def build_vproc_config_spec(lpar, spec, options)
+    desired_vprocs = options[:number_of_cpus].to_i
+
+    raise MiqException::MiqVmError, "Virtual processor count cannot be lower than #{lpar.minimum_vprocs}"   if desired_vprocs < lpar.minimum_vprocs.to_i
+    raise MiqException::MiqVmError, "Virtual processor count cannot be greater than #{lpar.maximum_vprocs}" if desired_vprocs > lpar.maximum_vprocs.to_i
+
+    spec[:desired_vprocs] = desired_vprocs
+  end
+
+  def build_netadap_create_config_spec(spec, options)
+    spec[:netadap_create] = options[:network_adapter_add].map do |adapt|
+      # Retrieve LAN attributes from DB.
+      switch_ids = HostSwitch.where(:host_id => host.id).pluck(:switch_id)
+      lan = Lan.find_by(:name => adapt[:network], :switch_id => switch_ids)
+      raise MiqException::MiqVmError, "Network [#{adapt[:network]}] is not available on target" if lan.nil?
+
+      {
+        :sys_uuid     => host.ems_ref,
+        :vswitch_uuid => lan.switch.uid_ems,
+        :attrs        => {:vlan_id => lan.tag}
+      }
+    end
+  end
+
+  def build_netadap_delete_config_spec(spec, options)
+    spec[:netadap_delete] = options[:network_adapter_remove].map do |adapt|
+      nic = nics.find_by(:address => adapt[:network][:mac])
+      raise MiqException::MiqVmError, "Network adapter [#{adapt[:network][:mac]}] is not available on target" if nic.nil?
+
+      nic.uid_ems
+    end
   end
 
   def raw_reconfigure(spec)

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
@@ -86,13 +86,8 @@ module ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm::Reconfigure
     $ibm_power_hmc_log.debug("reconfiguring with spec=#{spec}")
 
     ext_management_system.with_provider_connection do |connection|
-      if spec.key?(:desired_memory) || spec.key?(:desired_vprocs)
-        modify_attrs(
-          connection,
-          :desired_memory => spec[:desired_memory],
-          :desired_vprocs => spec[:desired_vprocs]
-        )
-      end
+      attrs = spec.slice(:desired_memory, :desired_vprocs)
+      modify_attrs(connection, attrs) unless attrs.empty?
 
       spec[:netadap_delete].try(:each) do |uuid|
         connection.network_adapter_lpar_delete(ems_ref, uuid)

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm/reconfigure.rb
@@ -1,0 +1,102 @@
+module ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm::Reconfigure
+  def reconfigurable?
+    host_hmc_managed
+  end
+
+  def max_total_vcpus
+    host ? host.hardware.cpu_total_cores : 1
+  end
+
+  def max_vcpus
+    max_total_vcpus
+  end
+
+  def max_cpu_cores_per_socket(_total_vcpus = nil)
+    1
+  end
+
+  def max_memory_mb
+    host ? host.hardware.memory_mb : 1_024
+  end
+
+  def build_config_spec(options)
+    $ibm_power_hmc_log.debug("building spec for #{options}")
+
+    spec = {}
+
+    lpar = ext_management_system.with_provider_connection { |connection| provider_object(connection) }
+
+    # Dynamic Reconfiguration requires RMC to be active.
+    raise MiqException::MiqVmError, "RMC is not active on target" if lpar.state == "running" && lpar.rmc_state != "active"
+
+    if options.key?(:vm_memory)
+      desired_memory = options[:vm_memory].to_i
+
+      raise MiqException::MiqVmError, "Memory cannot be lower than #{lpar.min_memory} MB"   if desired_memory < lpar.min_memory.to_i
+      raise MiqException::MiqVmError, "Memory cannot be greater than #{lpar.max_memory} MB" if desired_memory > lpar.max_memory.to_i
+      spec[:desired_memory] = desired_memory
+    end
+
+    if options.key?(:number_of_cpus)
+      desired_vprocs = options[:number_of_cpus].to_i
+
+      raise MiqException::MiqVmError, "Virtual processor count cannot be lower than #{lpar.minimum_vprocs}"   if desired_vprocs < lpar.minimum_vprocs.to_i
+      raise MiqException::MiqVmError, "Virtual processor count cannot be greater than #{lpar.maximum_vprocs}" if desired_vprocs > lpar.maximum_vprocs.to_i
+      spec[:desired_vprocs] = desired_vprocs
+    end
+
+    if options.key?(:network_adapter_add)
+      spec[:netadap_create] = options[:network_adapter_add].map do |adapt|
+        # Retrieve LAN attributes from DB.
+        switch_ids = HostSwitch.where(:host_id => host.id).pluck(:switch_id)
+        lan = Lan.find_by(:name => adapt[:network], :switch_id => switch_ids)
+        raise MiqException::MiqVmError, "Network [#{adapt[:network]}] is not available on target" if lan.nil?
+
+        {
+          :sys_uuid     => host.ems_ref,
+          :vswitch_uuid => lan.switch.uid_ems,
+          :attrs        => {:vlan_id => lan.tag}
+        }
+      end
+    end
+
+    if options.key?(:network_adapter_edit)
+      # HMC does not allow changing the VSWITCH or the VLAN of a client network adapter.
+      # It would require to delete and recreate the adapter with the same MAC.
+      raise MiqException::MiqVmError, "Cannot edit existing network adapter"
+    end
+
+    if options.key?(:network_adapter_remove)
+      spec[:netadap_delete] = options[:network_adapter_remove].map do |adapt|
+        nic = nics.find_by(:address => adapt[:network][:mac])
+        raise MiqException::MiqVmError, "Network adapter [#{adapt[:network][:mac]}] is not available on target" if nic.nil?
+
+        nic.uid_ems
+      end
+    end
+
+    spec
+  end
+
+  def raw_reconfigure(spec)
+    $ibm_power_hmc_log.debug("reconfiguring with spec=#{spec}")
+
+    ext_management_system.with_provider_connection do |connection|
+      if spec.key?(:desired_memory) || spec.key?(:desired_vprocs)
+        modify_attrs(
+          connection,
+          :desired_memory => spec[:desired_memory],
+          :desired_vprocs => spec[:desired_vprocs]
+        )
+      end
+
+      spec[:netadap_delete].try(:each) do |uuid|
+        connection.network_adapter_lpar_delete(ems_ref, uuid)
+      end
+
+      spec[:netadap_create].try(:each) do |netadap|
+        connection.network_adapter_lpar_create(ems_ref, netadap[:sys_uuid], netadap[:vswitch_uuid], netadap[:attrs])
+      end
+    end
+  end
+end

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.21.0"
+  spec.add_dependency "ibm_power_hmc", "~> 0.21.1"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.20.0"
+  spec.add_dependency "ibm_power_hmc", "~> 0.21.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Allow to modify memory and number of virtual processors of an LPAR or a VIOS (using DR if LPAR is running and RMC is active).
Allow to add/remove client network adapters to/from LPARs.
Disks reconfiguration is not supported by this PR.

![image](https://user-images.githubusercontent.com/48122102/201693095-d8ec139e-9794-48f0-8ad2-f993915f45c9.png)
