### PR TITLE
Add memory_type advanced setting (dedicated or shared) for VM & Templates

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -469,6 +469,16 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :value        => proc_type,
       :read_only    => true
     )
+
+    mem_type = lpar.shared_mem == "true" ? "shared" : "dedicated"
+    persister.vms_and_templates_advanced_settings.build(
+      :resource     => vm,
+      :name         => 'memory_type',
+      :display_name => _('Memory type'),
+      :description  => _('Dedicated or shared'),
+      :value        => mem_type,
+      :read_only    => true
+    )
   end
 
   def parse_templates

--- a/manageiq-providers-ibm_power_hmc.gemspec
+++ b/manageiq-providers-ibm_power_hmc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ibm_power_hmc", "~> 0.21.1"
+  spec.add_dependency "ibm_power_hmc", "~> 0.22.0"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
@@ -210,6 +210,12 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
       :read_only => true
     )
 
+    setting = vios.advanced_settings.find_by(:name => "memory_type")
+    expect(setting).to have_attributes(
+      :value     => "dedicated",
+      :read_only => true
+    )
+
     expect(vios.labels.count).to eq(1)
     expect(vios.labels.first.name).to eq("ManageIQ")
 
@@ -274,6 +280,12 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
       :read_only => true
     )
 
+    setting = lpar.advanced_settings.find_by(:name => "memory_type")
+    expect(setting).to have_attributes(
+      :value     => "dedicated",
+      :read_only => true
+    )
+
     expect(lpar.labels.count).to eq(1)
     expect(lpar.labels.first.name).to eq("ManageIQ")
 
@@ -303,6 +315,12 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
     setting = template.advanced_settings.find_by(:name => "processor_type")
     expect(setting).to have_attributes(
       :value     => "uncapped",
+      :read_only => true
+    )
+
+    setting = template.advanced_settings.find_by(:name => "memory_type")
+    expect(setting).to have_attributes(
+      :value     => "dedicated",
       :read_only => true
     )
   end


### PR DESCRIPTION
Following addition of shared memory pools to inventory (#115), add advanced setting to VMs and Templates, either set to "shared" or "dedicated", in a similar way to processors.

![image](https://user-images.githubusercontent.com/82665100/202725050-9a898447-4d9c-4205-9072-0f5b7bd81541.png)
