### PR TITLE
Restrict supported functionalities for archived VMs & Templates

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -1,5 +1,7 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm
-  supports :publish
+  supports :publish do
+    unsupported_reason_add(:provisioning, _('Not connected to ems')) if ext_management_system.nil?
+  end
 
   def provider_object(connection = nil)
     connection ||= ext_management_system.connect

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
@@ -1,6 +1,15 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
-  supports :provisioning
-  supports :clone
+  supports :provisioning do
+    if ext_management_system
+      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+    else
+      unsupported_reason_add(:provisioning, _('Not connected to ems'))
+    end
+  end
+
+  supports :clone do
+    unsupported_reason_add(:clone, _('Not connected to ems')) if ext_management_system.nil?
+  end
 
   def do_request(request_type, options)
     case request_type

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
@@ -20,14 +20,17 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar do
   end
 
   context "lpar" do
+    let(:archived_vm) { FactoryBot.create(:ibm_power_hmc_lpar, :ext_management_system => nil, :ems_ref => "3F3D399B-DFF3-4977-8881-C194AA47CD3A", :host => host) }
+
     it "supports clone" do
-      expect(described_class.supports?(:clone)).to be false
+      expect(vm.supports?(:clone)).to be false
     end
     it "supports publish" do
-      expect(described_class.supports?(:publish)).to (be true), "unsupported reason: #{described_class.unsupported_reason(:publish)}"
+      expect(vm.supports?(:publish)).to (be true), "unsupported reason: #{described_class.unsupported_reason(:publish)}"
+      expect(archived_vm.supports?(:publish)).to be false
     end
     it "supports migrate" do
-      expect(described_class.supports?(:migrate)).to be false
+      expect(vm.supports?(:migrate)).to be false
     end
     it "supports power operations" do
       host.advanced_settings.create!(:name => "hmc_managed", :value => "true")

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/template_spec.rb
@@ -1,10 +1,16 @@
 describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Template do
+  let(:ems)               { FactoryBot.create(:ems_ibm_power_hmc_infra_with_authentication) }
+  let(:template)          { FactoryBot.create(:ibm_power_hmc_template, :ext_management_system => ems, :ems_ref => "template1_uuid", :name => "template1") }
+  let(:archived_template) { FactoryBot.create(:ibm_power_hmc_template, :ext_management_system => nil, :ems_ref => "template2_uuid", :name => "template2") }
+
   context "template" do
     it "supports clone" do
-      expect(described_class.supports?(:clone)).to be true
+      expect(template.supports?(:clone)).to (be true), "unsupported reason: #{described_class.unsupported_reason(:clone)}"
+      expect(archived_template.supports?(:clone)).to be false
     end
     it "supports provisioning" do
-      expect(described_class.supports?(:provisioning)).to be true
+      expect(template.supports?(:provisioning)).to (be true), "unsupported reason: #{described_class.unsupported_reason(:provisioning)}"
+      expect(archived_template.supports?(:provisioning)).to be false
     end
   end
 end


### PR DESCRIPTION
Supported functionalities for VMs & Templates of type "provisionning", "clone" and "publish" are currently set without conditions. The UI therefore lets user initiate such a request on archived VMs & Templates which inevitably results in this error:

![image](https://user-images.githubusercontent.com/82665100/203278921-4814ecbc-99ad-4b9f-b270-0b5ecb746ef2.png)

Proposed fix it to check at the instance level that VM or Template is not archived (i.e. it has an EMS), so the UI rejects requets.

At best, the menu item is disabled, like so:
![image](https://user-images.githubusercontent.com/82665100/203282960-7766c8fe-dfbd-46cf-a046-08bb3591ca4b.png)

At the very least, the request fails in a clean way:
![image](https://user-images.githubusercontent.com/82665100/203282864-cd7e02bc-bbfa-4dd7-be53-9117393f5d02.png)
