### PR TITLE
fix rubocop Layout/RescueEnsureAlignment errors

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/infra_manager.rb
@@ -9,12 +9,10 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   attr_reader :connection
 
   def hmc
-    @hmc ||= begin
-      connection.management_console
-    rescue => e
-      $ibm_power_hmc_log.error("management console query failed: #{e}")
-      raise
-    end
+    @hmc ||= connection.management_console
+  rescue => e
+    $ibm_power_hmc_log.error("management console query failed: #{e}")
+    raise
   end
 
   def groups
@@ -25,21 +23,17 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def ssps
-    @ssps ||= begin
-      connection.ssps
-    rescue => e
-      $ibm_power_hmc_log.error("ssps query failed: #{e}")
-      raise
-    end
+    @ssps ||= connection.ssps
+  rescue => e
+    $ibm_power_hmc_log.error("ssps query failed: #{e}")
+    raise
   end
 
   def cecs_quick
-    @cecs_quick ||= begin
-      connection.managed_systems_quick
-    rescue => e
-      $ibm_power_hmc_log.error("managed systems quick query failed: #{e}")
-      raise
-    end
+    @cecs_quick ||= connection.managed_systems_quick
+  rescue => e
+    $ibm_power_hmc_log.error("managed systems quick query failed: #{e}")
+    raise
   end
 
   def self.cec_unavailable?(cec_quick)
@@ -47,14 +41,15 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def cecs
-    @cecs ||= cecs_quick.map do |cec_quick|
-      connection.managed_system(cec_quick["UUID"], "SystemNetwork") unless self.class.cec_unavailable?(cec_quick)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("managed system query failed for #{cec_quick["UUID"]}: #{e}")
-      raise
-    end.compact
+    @cecs ||=
+      cecs_quick.map do |cec_quick|
+        connection.managed_system(cec_quick["UUID"], "SystemNetwork") unless self.class.cec_unavailable?(cec_quick)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("managed system query failed for #{cec_quick["UUID"]}: #{e}")
+        raise
+      end.compact
   end
 
   def cecs_unavailable
@@ -66,12 +61,13 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def cec_cpu_freqs_from_api
-    @cec_cpu_freqs_from_api ||= cecs.map do |sys|
-      [sys.uuid, cec_cpu_freq(sys)]
-    rescue => e
-      $ibm_power_hmc_log.error("cpu frequency query failed for #{sys.uuid}: #{e}")
-      nil
-    end.compact.to_h
+    @cec_cpu_freqs_from_api ||=
+      cecs.map do |sys|
+        [sys.uuid, cec_cpu_freq(sys)]
+      rescue => e
+        $ibm_power_hmc_log.error("cpu frequency query failed for #{sys.uuid}: #{e}")
+        nil
+      end.compact.to_h
   end
 
   def cec_cpu_freqs
@@ -79,67 +75,70 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def vlans
-    @vlans ||= cecs.map do |sys|
-      [sys.uuid, connection.virtual_networks(sys.uuid)] unless sys.networks_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("virtual networks query failed for #{sys.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @vlans ||=
+      cecs.map do |sys|
+        [sys.uuid, connection.virtual_networks(sys.uuid)] unless sys.networks_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("virtual networks query failed for #{sys.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
 
   def vswitches
-    @vswitches ||= cecs.map do |sys|
-      [sys.uuid, connection.virtual_switches(sys.uuid)] unless sys.vswitches_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("virtual switches query failed for #{sys.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @vswitches ||=
+      cecs.map do |sys|
+        [sys.uuid, connection.virtual_switches(sys.uuid)] unless sys.vswitches_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("virtual switches query failed for #{sys.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
 
   def lpars
-    @lpars ||= cecs.flat_map do |sys|
-      connection.lpars(sys.uuid, nil, "None") unless sys.lpars_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("lpars query failed for #{sys.uuid}: #{e}")
-      raise
-    end.compact
+    @lpars ||=
+      cecs.flat_map do |sys|
+        connection.lpars(sys.uuid, nil, "None") unless sys.lpars_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("lpars query failed for #{sys.uuid}: #{e}")
+        raise
+      end.compact
   end
 
   def vioses
-    @vioses ||= cecs.flat_map do |sys|
-      connection.vioses(sys.uuid) unless sys.vioses_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("vioses query failed for #{sys.uuid} #{e}")
-      raise
-    end.compact
+    @vioses ||=
+      cecs.flat_map do |sys|
+        connection.vioses(sys.uuid) unless sys.vioses_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("vioses query failed for #{sys.uuid} #{e}")
+        raise
+      end.compact
   end
 
   def vioses_quick
-    @vioses_quick ||= cecs.map do |sys|
-      [sys.uuid, connection.vioses_quick(sys.uuid)] unless sys.vioses_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("vioses quick query failed for #{sys.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @vioses_quick ||=
+      cecs.map do |sys|
+        [sys.uuid, connection.vioses_quick(sys.uuid)] unless sys.vioses_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("vioses quick query failed for #{sys.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
 
   def pcm_enabled
-    @pcm_enabled ||= begin
-      connection.pcm_preferences.first.managed_system_preferences.index_by(&:id)
-    rescue => e
-      $ibm_power_hmc_log.error("pcm preferences query failed: #{e}")
-      raise
-    end
+    @pcm_enabled ||= connection.pcm_preferences.first.managed_system_preferences.index_by(&:id)
+  rescue => e
+    $ibm_power_hmc_log.error("pcm preferences query failed: #{e}")
+    raise
   end
 
   def vscsi_mappings
@@ -149,26 +148,28 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def netadapters_lpar
-    @netadapters_lpar ||= lpars.map do |lpar|
-      [lpar.uuid, connection.network_adapter_lpar(lpar.uuid)] unless lpar.net_adap_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("network adapters query failed for lpar #{lpar.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @netadapters_lpar ||=
+      lpars.map do |lpar|
+        [lpar.uuid, connection.network_adapter_lpar(lpar.uuid)] unless lpar.net_adap_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("network adapters query failed for lpar #{lpar.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
   private :netadapters_lpar
 
   def netadapters_vios
-    @netadapters_vios ||= vioses.map do |vios|
-      [vios.uuid, connection.network_adapter_vios(vios.uuid)] unless vios.net_adap_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("network adapters query failed for vios #{vios.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @netadapters_vios ||=
+      vioses.map do |vios|
+        [vios.uuid, connection.network_adapter_vios(vios.uuid)] unless vios.net_adap_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("network adapters query failed for vios #{vios.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
   private :netadapters_vios
 
@@ -177,26 +178,28 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def sriov_elps_lpar
-    @sriov_elps_lpar ||= lpars.map do |lpar|
-      [lpar.uuid, connection.sriov_elp_lpar(lpar.uuid)] unless lpar.sriov_elp_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("sriov ethernet logical ports query failed for lpar #{lpar.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @sriov_elps_lpar ||=
+      lpars.map do |lpar|
+        [lpar.uuid, connection.sriov_elp_lpar(lpar.uuid)] unless lpar.sriov_elp_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("sriov ethernet logical ports query failed for lpar #{lpar.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
   private :sriov_elps_lpar
 
   def sriov_elps_vios
-    @sriov_elps_vios ||= vioses.map do |vios|
-      [vios.uuid, connection.sriov_elp_vios(vios.uuid)] unless vios.sriov_elp_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("sriov ethernet logical ports query failed for vios #{vios.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @sriov_elps_vios ||=
+      vioses.map do |vios|
+        [vios.uuid, connection.sriov_elp_vios(vios.uuid)] unless vios.sriov_elp_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("sriov ethernet logical ports query failed for vios #{vios.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
   private :sriov_elps_vios
 
@@ -205,25 +208,27 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def vnics
-    @vnics ||= lpars.map do |lpar|
-      [lpar.uuid, connection.vnic_dedicated(lpar.uuid)] unless lpar.vnic_dedicated_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("vnics query failed for #{lpar.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @vnics ||=
+      lpars.map do |lpar|
+        [lpar.uuid, connection.vnic_dedicated(lpar.uuid)] unless lpar.vnic_dedicated_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("vnics query failed for #{lpar.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
 
   def vscsi_client_adapters
-    @vscsi_client_adapters ||= lpars.map do |lpar|
-      [lpar.uuid, connection.vscsi_client_adapter(lpar.uuid)] unless lpar.vscsi_client_uuids.empty?
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("vscsi client adapters query failed for #{lpar.uuid}: #{e}")
-      raise
-    end.compact.to_h
+    @vscsi_client_adapters ||=
+      lpars.map do |lpar|
+        [lpar.uuid, connection.vscsi_client_adapter(lpar.uuid)] unless lpar.vscsi_client_uuids.empty?
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("vscsi client adapters query failed for #{lpar.uuid}: #{e}")
+        raise
+      end.compact.to_h
   end
 
   def lpar_disks_from_db
@@ -251,34 +256,34 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::InfraManager < Man
   end
 
   def templates
-    @templates ||= begin
-      connection.templates
-    rescue => e
-      $ibm_power_hmc_log.error("templates query failed: #{e}")
-      raise
-    end
+    @templates ||= connection.templates
+  rescue => e
+    $ibm_power_hmc_log.error("templates query failed: #{e}")
+    raise
   end
 
   def shared_processor_pools
-    @shared_processor_pools ||= cecs.flat_map do |sys|
-      connection.shared_processor_pool(sys.uuid)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("shared processor pool query failed for #{sys.uuid}: #{e}")
-      raise
-    end.compact
+    @shared_processor_pools ||=
+      cecs.flat_map do |sys|
+        connection.shared_processor_pool(sys.uuid)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("shared processor pool query failed for #{sys.uuid}: #{e}")
+        raise
+      end.compact
   end
 
   def shared_memory_pools
-    @shared_memory_pools ||= cecs.flat_map do |sys|
-      connection.shared_memory_pool(sys.uuid)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue IbmPowerHmc::Connection::HttpError => e
-      $ibm_power_hmc_log.error("shared_memory_pool query failed for #{sys.uuid}: #{e}")
-      raise
-    end.compact
+    @shared_memory_pools ||=
+      cecs.flat_map do |sys|
+        connection.shared_memory_pool(sys.uuid)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue IbmPowerHmc::Connection::HttpError => e
+        $ibm_power_hmc_log.error("shared memory pool query failed for #{sys.uuid}: #{e}")
+        raise
+      end.compact
   end
 
   private

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector/target_collection.rb
@@ -13,14 +13,15 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
   end
 
   def cecs_quick
-    @cecs_quick ||= references(:hosts).map do |ems_ref|
-      connection.managed_system_quick(ems_ref).merge("UUID" => ems_ref)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("managed systems quick query failed for #{ems_ref}: #{e}")
-      raise
-    end.compact
+    @cecs_quick ||=
+      references(:hosts).map do |ems_ref|
+        connection.managed_system_quick(ems_ref).merge("UUID" => ems_ref)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("managed systems quick query failed for #{ems_ref}: #{e}")
+        raise
+      end.compact
   end
 
   def cec_cpu_freqs_from_db
@@ -34,84 +35,91 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector::TargetCollection <
   end
 
   def lpars
-    @lpars ||= references(:vms).map do |ems_ref|
-      connection.lpar(ems_ref, nil, "None")
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying lpar #{ems_ref}: #{e}")
-      raise
-    end.compact
+    @lpars ||=
+      references(:vms).map do |ems_ref|
+        connection.lpar(ems_ref, nil, "None")
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying lpar #{ems_ref}: #{e}")
+        raise
+      end.compact
   end
 
   def vioses
-    @vioses ||= references(:vms).map do |ems_ref|
-      connection.vios(ems_ref)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying vios #{ems_ref}: #{e}")
-      raise
-    end.compact
+    @vioses ||=
+      references(:vms).map do |ems_ref|
+        connection.vios(ems_ref)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying vios #{ems_ref}: #{e}")
+        raise
+      end.compact
   end
 
   def templates
-    @templates ||= references(:miq_templates).map do |ems_ref|
-      connection.template(ems_ref)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying template #{ems_ref}: #{e}")
-      raise
-    end.compact
+    @templates ||=
+      references(:miq_templates).map do |ems_ref|
+        connection.template(ems_ref)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying template #{ems_ref}: #{e}")
+        raise
+      end.compact
   end
 
   def clusters
-    @clusters ||= references(:storages).map do |ems_ref|
-      connection.cluster(ems_ref)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying cluster #{ems_ref}: #{e}")
-      raise
-    end.compact
+    @clusters ||=
+      references(:storages).map do |ems_ref|
+        connection.cluster(ems_ref)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying cluster #{ems_ref}: #{e}")
+        raise
+      end.compact
   end
   private :clusters
 
   def ssps
     # NOTE: We're using cluster ID as ems_ref for shared storage pools.
-    @ssps ||= clusters.map do |cluster|
-      connection.ssp(cluster.ssp_uuid)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying ssp #{cluster.ssp_uuid}: #{e}")
-      raise
-    end.compact
+    @ssps ||=
+      clusters.map do |cluster|
+        connection.ssp(cluster.ssp_uuid)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying ssp #{cluster.ssp_uuid}: #{e}")
+        raise
+      end.compact
   end
 
   def shared_processor_pools
-    @shared_processor_pools ||= references(:resource_pools).map do |ems_ref|
-      sys_uuid, pool_uuid = ems_ref.split("_")
-      connection.shared_processor_pool(sys_uuid, pool_uuid)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying shared processor pool #{pool_uuid} on cec #{sys_uuid}: #{e}")
-      raise
-    end.compact
+    @shared_processor_pools ||=
+      references(:resource_pools).map do |ems_ref|
+        sys_uuid, pool_uuid = ems_ref.split("_")
+        connection.shared_processor_pool(sys_uuid, pool_uuid)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying shared processor pool #{pool_uuid} on cec #{sys_uuid}: #{e}")
+        raise
+      end.compact
   end
 
   def shared_memory_pools
-    @shared_memory_pools ||= references(:resource_pools).map do |ems_ref|
-      sys_uuid, pool_uuid = ems_ref.split("_")
-      connection.shared_memory_pool(sys_uuid, pool_uuid)
-    rescue IbmPowerHmc::Connection::HttpNotFound
-      nil
-    rescue => e
-      $ibm_power_hmc_log.error("error querying shared memory pool #{pool_uuid} on cec #{sys_uuid}: #{e}")
-      raise
-    end.compact
+    @shared_memory_pools ||=
+      references(:resource_pools).map do |ems_ref|
+        sys_uuid, pool_uuid = ems_ref.split("_")
+        connection.shared_memory_pool(sys_uuid, pool_uuid)
+      rescue IbmPowerHmc::Connection::HttpNotFound
+        nil
+      rescue => e
+        $ibm_power_hmc_log.error("error querying shared memory pool #{pool_uuid} on cec #{sys_uuid}: #{e}")
+        raise
+      end.compact
   end
 
   def infer_related_ems_refs_api!


### PR DESCRIPTION
Running `bundle exec rubocop` leads to a bunch of `Layout/RescueEnsureAlignment` rubocop offenses that are not checked by CI.