### PR TITLE
collect media repositories as ISO storages

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -26,7 +26,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
 
   has_many :hosts_advanced_settings, :through => :hosts, :source => :advanced_settings
   has_many :media_repositories, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
-  has_many :iso_images, :through => :storages
+  has_many :iso_images, :through => :media_repositories
 
   def self.params_for_create
     {

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -17,6 +17,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   require_nested :ResourcePool
   require_nested :MemoryResourcePool
   require_nested :ProcessorResourcePool
+  require_nested :MediaRepository
 
   supports :create
   supports :metrics
@@ -24,6 +25,8 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   supports :provisioning
 
   has_many :hosts_advanced_settings, :through => :hosts, :source => :advanced_settings
+  has_many :media_repositories, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :iso_images, :through => :storages
 
   def self.params_for_create
     {

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/media_repository.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/media_repository.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::IbmPowerHmc::InfraManager::MediaRepository < ManageIQ::Providers::IbmPowerHmc::InfraManager::Storage
+  supports :iso_datastore
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+
+  def self.display_name(number = 1)
+    n_("Media Repository", "Media Repositories", number)
+  end
+end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/media_repository.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/media_repository.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::MediaRepository < ManageIQ::Providers::IbmPowerHmc::InfraManager::Storage
   supports :iso_datastore
 
-  belongs_to :ext_management_system, :foreign_key => :ems_id
-
   def self.display_name(number = 1)
     n_("Media Repository", "Media Repositories", number)
   end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -93,6 +93,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   def parse_ssps
     collector.ssps.each do |ssp|
       persister.storages.build(
+        :store_type  => "SSP",
         :name        => ssp.name,
         :total_space => self.class.storage_capacity(ssp),
         :ems_ref     => ssp.cluster_uuid,
@@ -236,7 +237,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       parse_vios_disks(vios, hardware)
       parse_vios_networks(vios, hardware)
       parse_vios_guest_devices(vios, hardware)
-      parse_media_repository(vios)
+      parse_vios_media_repository(vios)
     end
   end
 
@@ -323,7 +324,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
     end
   end
 
-  def parse_media_repository(vios)
+  def parse_vios_media_repository(vios)
     return if vios.rep.nil?
 
     storage = persister.storages.build(
@@ -333,7 +334,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       :name        => vios.rep.name,
       :total_space => self.class.storage_capacity(vios.rep)
     )
-
+    # Populate with ISO images.
     vios.rep.vopts.each do |vopt|
       persister.iso_images.build(
         :storage => storage,

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -34,5 +34,12 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :vm_resource_pools)
     add_collection(infra, :parent_blue_folders)
     add_collection(infra, :vm_and_template_labels)
+    add_collection(infra, :iso_images) do |builder|
+      builder.add_properties(
+        :manager_ref                  => %i[storage name],
+        :model_class                  => ::IsoImage,
+        :parent_inventory_collections => %i[storages]
+      )
+    end
   end
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister/infra_manager.rb
@@ -34,12 +34,6 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister::InfraManager < Man
     add_collection(infra, :vm_resource_pools)
     add_collection(infra, :parent_blue_folders)
     add_collection(infra, :vm_and_template_labels)
-    add_collection(infra, :iso_images) do |builder|
-      builder.add_properties(
-        :manager_ref                  => %i[storage name],
-        :model_class                  => ::IsoImage,
-        :parent_inventory_collections => %i[storages]
-      )
-    end
+    add_collection(infra, :iso_images)
   end
 end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
@@ -225,7 +225,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
     # VMs with dedicated CPUs have no shared processor pool.
     expect(vios.parent_resource_pool).to be_nil
 
-    repo = ems.media_repositories.find_by(:store_type => "ISO", :ems_ref => vios_uuid)
+    repo = ems.media_repositories.find_by(:ems_ref => vios_uuid)
     expect(repo).to have_attributes(
       :store_type  => "ISO",
       :name        => "VMLibrary",

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
@@ -224,6 +224,15 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
 
     # VMs with dedicated CPUs have no shared processor pool.
     expect(vios.parent_resource_pool).to be_nil
+
+    repo = ems.media_repositories.find_by(:store_type => "ISO", :ems_ref => vios_uuid)
+    expect(repo).to have_attributes(
+      :store_type  => "ISO",
+      :name        => "VMLibrary",
+      :total_space => 45.gigabytes
+    )
+    iso = repo.iso_images.find_by(:name => "rhel84")
+    expect(iso).not_to be nil
   end
 
   def assert_specific_lpar
@@ -342,9 +351,10 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
   def assert_specific_storage
     storage = ems.storages.find_by(:ems_ref => storage_uuid)
     expect(storage).to have_attributes(
-      :ems_ref => storage_uuid,
-      :name    => "SSP_1",
-      :type    => "ManageIQ::Providers::IbmPowerHmc::InfraManager::Storage"
+      :ems_ref    => storage_uuid,
+      :store_type => "SSP",
+      :name       => "SSP_1",
+      :type       => "ManageIQ::Providers::IbmPowerHmc::InfraManager::Storage"
     )
   end
 end


### PR DESCRIPTION
With PowerVM, each VIOS can have a virtual media repository containing ISO images that can then be mapped to LPARs via VSCSI:

![image](https://user-images.githubusercontent.com/48122102/205962791-ec98c28a-aae7-4e76-a687-0c0bb6fabd80.png)

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/22239