### PR TITLE
Use better text for user-facing errors

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm
   supports :publish do
-    unsupported_reason_add(:provisioning, _('Not connected to ems')) if ext_management_system.nil?
+    unsupported_reason_add(:provisioning, _('The LPAR is not connected to an active Provider')) if ext_management_system.nil?
   end
 
   supports :reconfigure_network_adapters

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
@@ -3,12 +3,12 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Template < ManageIQ::Provi
     if ext_management_system
       unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('Not connected to ems'))
+      unsupported_reason_add(:provisioning, _('The Template is not connected to an active Provider'))
     end
   end
 
   supports :clone do
-    unsupported_reason_add(:clone, _('Not connected to ems')) if ext_management_system.nil?
+    unsupported_reason_add(:clone, _('The Template is not connected to an active Provider')) if ext_management_system.nil?
   end
 
   def do_request(request_type, options)


### PR DESCRIPTION
The term "ems" is an insider term. This commit uses the same "not connected" text that we use in core.

See also https://github.com/ManageIQ/manageiq/pull/22284#discussion_r1060844227