### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
 
   supports :create
   supports :metrics
-  supports :native_console
+  supports :management_console
   supports :provisioning
 
   has_many :hosts_advanced_settings, :through => :hosts, :source => :advanced_settings

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -19,10 +19,10 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
     unsupported_reason_add(:set_description, _("Host is not HMC-managed")) unless host_hmc_managed
   end
 
-  supports :native_console do
+  supports :management_console do
     reason ||= _("VM Console not supported because VM is orphaned") if orphaned?
     reason ||= _("VM Console not supported because VM is archived") if archived?
-    unsupported_reason_add(:native_console, reason) if reason
+    unsupported_reason_add(:management_console, reason) if reason
   end
 
   def provider_object(_connection = nil)


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22474

Changes the feature name for the IBM providers from native_console to management_console since native_console is already used by the RHV provider.