### PR TITLE
Use the correct PHYP product name

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser/infra_manager.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < ManageIQ::Providers::IbmPowerHmc::Inventory::Parser
+  OS_MAP = {
+    'phyp' => 'IBM PowerVM hypervisor (PHYP)'
+  }.freeze
+
   def parse
     $ibm_power_hmc_log.info("#{self.class}##{__method__} start")
     collector.collect! do
@@ -48,7 +52,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
       )
       persister.host_operating_systems.build(
         :host         => host,
-        :product_name => "phyp",
+        :product_name => OS_MAP['phyp'],
         :build_number => sys["SystemFirmware"]
       )
       persister.host_hardwares.build(
@@ -147,7 +151,7 @@ class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser::InfraManager < Manage
   def parse_host_operating_system(host, sys)
     persister.host_operating_systems.build(
       :host         => host,
-      :product_name => "phyp",
+      :product_name => OS_MAP['phyp'],
       :build_number => sys.fwversion
     )
   end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
@@ -105,7 +105,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
       :vmm_vendor  => "ibm_power_hmc"
     )
     expect(host.operating_system).to have_attributes(
-      :product_name => "phyp",
+      :product_name => "IBM PowerVM hypervisor (PHYP)",
       :build_number => "SV860_FW860.61 (185)"
     )
     expect(host.hardware).to have_attributes(


### PR DESCRIPTION
IBM PowerVM hypervisor (PHYP) is the correct product name.

Example:
![image](https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/assets/1637291/1d42027f-7476-467a-ae45-8b7c5681ada8)

Note that the PowerVM hypervisor (commonly referred to as PHYP) doesn't have it's own icon. It is a fundamental component of PowerVM, though, so using the magic of [`OperatingSystem.normalize_os_name`](https://github.com/ManageIQ/manageiq/blob/master/app/models/operating_system.rb?plain=1#L76C12-L84) this PowerVM icon will be displayed.

Depends on:
- https://github.com/ManageIQ/manageiq-decorators/pull/89
- https://github.com/ManageIQ/manageiq/pull/22523