### PR TITLE
Fix provisioning dialog 'src_vm_id' method

### DIFF
--- a/content/miq_dialogs/miq_provision_ibm_power_hmc_dialogs_template.yaml
+++ b/content/miq_dialogs/miq_provision_ibm_power_hmc_dialogs_template.yaml
@@ -23,6 +23,11 @@
           :display: :hide
           :data_type: :string
         :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+
+            :method: :allowed_templates
           :description: Name
           :required: true
           :notes:


### PR DESCRIPTION
The 'allowed_templates' method is a core method to generate a list of
templates for the selection dialog. This is explicitly necessary when
creating a catalog item since the user selects the template after
entering into the request dialog (in contrast to the 'Lifecycle >
Provision VMs using this Template' which auto-selects the template).

Without this, the following exception is raised when attempting to
definite a Power HMC VM provision catalog item:

FATAL -- : Error caught: [NoMethodError] undefined method `any?' for nil:NilClass
