### PR TITLE
Change default API port to 443

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -79,7 +79,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
                   :name         => "endpoints.default.port",
                   :label        => _("API Port"),
                   :type         => "number",
-                  :initialValue => 12_443,
+                  :initialValue => 443,
                   :isRequired   => true,
                   :validate     => [{:type => "required"}],
                 },


### PR DESCRIPTION
Port 443 is the preferred default port to access the HMC API. While port
12443 is also open by default in the latest HMC (v10) I'm told that may
change.
