### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -1,24 +1,4 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::InfraManager
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :EventTargetParser
-  require_nested :Host
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Template
-  require_nested :Vm
-  require_nested :Lpar
-  require_nested :Vios
-  require_nested :Storage
-  require_nested :ResourcePool
-  require_nested :MemoryResourcePool
-  require_nested :ProcessorResourcePool
-  require_nested :MediaRepository
-
   supports :catalog
   supports :create
   supports :metrics

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "ibm_power_hmc"
 
   def friendly_name

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/provision.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/provision.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Provision < MiqProvision
-  include_concern 'Cloning'
-  include_concern 'StateMachine'
+  include Cloning
+  include StateMachine
 
   VALID_REQUEST_TYPES = %w[clone_to_template template].freeze
   validates :request_type, :inclusion => {:in => VALID_REQUEST_TYPES, :message => "should be one of: #{VALID_REQUEST_TYPES.join(', ')}"}

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/refresh_worker.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -1,7 +1,6 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::InfraManager::Vm
   include ManageIQ::Providers::IbmPowerHmc::InfraManager::MetricsCaptureMixin
-
-  include_concern "Reconfigure"
+  include Reconfigure
 
   virtual_delegate :hmc_managed, :to => :host, :prefix => true, :allow_nil => true, :type => :boolean
 

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::IbmPowerHmc::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/collector.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/collector.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::IbmPowerHmc::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :InfraManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/parser.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::IbmPowerHmc::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :InfraManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/ibm_power_hmc/inventory/persister.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::IbmPowerHmc::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :InfraManager
-  require_nested :TargetCollection
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854