### PR TITLE
drop unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
@@ -2,23 +2,23 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Host < ::Host
   include ManageIQ::Providers::IbmPowerHmc::InfraManager::MetricsCaptureMixin
 
   supports :capture do
-    unsupported_reason_add(:capture, _("PCM not enabled for this Host")) unless pcm_enabled
+    _("PCM not enabled for this Host") unless pcm_enabled
   end
 
   supports :stop do
-    unsupported_reason_add(:stop, _("Cannot shutdown a host that is powered off")) unless power_state == "on"
-    unsupported_reason_add(:stop, _("Cannot shutdown a host that is not HMC-managed")) unless hmc_managed
+    return _("Cannot shutdown a host that is powered off") unless power_state == "on"
+    return _("Cannot shutdown a host that is not HMC-managed") unless hmc_managed
   end
 
   supports :shutdown do
-    unsupported_reason_add(:shutdown, _("Cannot shutdown a host that is powered off")) unless power_state == "on"
-    unsupported_reason_add(:shutdown, _("Cannot shutdown a host with running vms")) if vms.where(:power_state => "on").any?
-    unsupported_reason_add(:shutdown, _("Cannot shutdown a host that is not HMC-managed")) unless hmc_managed
+    return _("Cannot shutdown a host that is powered off") unless power_state == "on"
+    return _("Cannot shutdown a host with running vms") if vms.where(:power_state => "on").any?
+    return _("Cannot shutdown a host that is not HMC-managed") unless hmc_managed
   end
 
   supports :start do
-    unsupported_reason_add(:start, _("Cannot start a host that is already powered on")) unless power_state == "off"
-    unsupported_reason_add(:start, _("Cannot start a host that is not HMC-managed")) unless hmc_managed
+    return _("Cannot start a host that is already powered on") unless power_state == "off"
+    return _("Cannot start a host that is not HMC-managed") unless hmc_managed
   end
 
   def shutdown

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar.rb
@@ -1,13 +1,16 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar < ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm
   supports :publish do
-    unsupported_reason_add(:provisioning, _('The LPAR is not connected to an active Provider')) if ext_management_system.nil?
+    _('The LPAR is not connected to an active Provider') if ext_management_system.nil?
   end
 
   supports :reconfigure_network_adapters
 
   supports :terminate do
-    unsupported_reason_add(:terminate, unsupported_reason(:control)) unless supports_control?
-    unsupported_reason_add(:terminate, _("Cannot delete a running partition")) unless power_state == "off"
+    if power_state == "off"
+      unsupported_reason(:control)
+    else
+      _("Cannot delete a running partition")
+    end
   end
 
   def provider_object(connection = nil)

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/template.rb
@@ -1,14 +1,14 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
   supports :provisioning do
     if ext_management_system
-      unsupported_reason_add(:provisioning, ext_management_system.unsupported_reason(:provisioning)) unless ext_management_system.supports?(:provisioning)
+      ext_management_system.unsupported_reason(:provisioning)
     else
-      unsupported_reason_add(:provisioning, _('The Template is not connected to an active Provider'))
+      _('The Template is not connected to an active Provider')
     end
   end
 
   supports :clone do
-    unsupported_reason_add(:clone, _('The Template is not connected to an active Provider')) if ext_management_system.nil?
+    _('The Template is not connected to an active Provider') if ext_management_system.nil?
   end
 
   def do_request(request_type, options)

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -7,21 +7,19 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
   supports :capture
 
   supports :control do
-    unsupported_reason_add(:control, _("Host is not HMC-managed")) unless host_hmc_managed
+    _("Host is not HMC-managed") unless host_hmc_managed
   end
 
   supports :rename do
-    unsupported_reason_add(:rename, _("Host is not HMC-managed")) unless host_hmc_managed
+    _("Host is not HMC-managed") unless host_hmc_managed
   end
 
   supports :set_description do
-    unsupported_reason_add(:set_description, _("Host is not HMC-managed")) unless host_hmc_managed
+    _("Host is not HMC-managed") unless host_hmc_managed
   end
 
   supports :native_console do
-    reason ||= _("VM Console not supported because VM is orphaned") if orphaned?
-    reason ||= _("VM Console not supported because VM is archived") if archived?
-    unsupported_reason_add(:native_console, reason) if reason
+    unsupported_reason(:action)
   end
 
   def provider_object(_connection = nil)


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
