### PR TITLE
Remove return from supports block

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/host.rb
@@ -6,19 +6,29 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Host < ::Host
   end
 
   supports :stop do
-    return _("Cannot shutdown a host that is powered off") unless power_state == "on"
-    return _("Cannot shutdown a host that is not HMC-managed") unless hmc_managed
+    if power_state != "on"
+      _("Cannot shutdown a host that is powered off")
+    elsif !hmc_managed
+      _("Cannot shutdown a host that is not HMC-managed")
+    end
   end
 
   supports :shutdown do
-    return _("Cannot shutdown a host that is powered off") unless power_state == "on"
-    return _("Cannot shutdown a host with running vms") if vms.where(:power_state => "on").any?
-    return _("Cannot shutdown a host that is not HMC-managed") unless hmc_managed
+    if power_state != "on"
+      _("Cannot shutdown a host that is powered off")
+    elsif vms.where(:power_state => "on").any?
+      _("Cannot shutdown a host with running vms")
+    elsif !hmc_managed
+      _("Cannot shutdown a host that is not HMC-managed")
+    end
   end
 
   supports :start do
-    return _("Cannot start a host that is already powered on") unless power_state == "off"
-    return _("Cannot start a host that is not HMC-managed") unless hmc_managed
+    if power_state != "off"
+      _("Cannot start a host that is already powered on")
+    elsif !hmc_managed
+      _("Cannot start a host that is not HMC-managed")
+    end
   end
 
   def shutdown


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/22898 (as a followup)

Introduced by https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/153

You can not have a return in a block. It causes a LongJump error Besides, it tries to return from inside the calling block - not what we want.
