### PR TITLE
Refresh entire provider for special LPAR UUID

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -1,6 +1,8 @@
 class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
   attr_reader :ems_event
 
+  NO_UUID_VALUE = "88888888-8888-8888-8888-888888888888" # Returned when no UUID assigned to LPAR
+
   def initialize(ems_event)
     @ems_event = ems_event
   end
@@ -39,7 +41,11 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
         # have changed (e.g. RMCState, PartitionName, PartitionState etc...)
         # This may be used to perform quick property REST API calls to the HMC
         # instead of querying the full LPAR data.
-        new_targets << {:assoc => :vms, :ems_ref => elems[:uuid]}
+        if elems[:uuid].eql?(NO_UUID_VALUE)
+          new_targets << ems_event.ext_management_system
+        else
+          new_targets << {:assoc => :vms, :ems_ref => elems[:uuid]}
+        end
       when "VirtualSwitch", "VirtualNetwork"
         if elems.key?(:manager_uuid)
           new_targets << {:assoc => :hosts, :ems_ref => elems[:manager_uuid]}

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -42,7 +42,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
         # have changed (e.g. RMCState, PartitionName, PartitionState etc...)
         # This may be used to perform quick property REST API calls to the HMC
         # instead of querying the full LPAR data.
-        if elems[:uuid].eql?(NO_UUID_VALUE)
+        if elems[:uuid] == NO_UUID_VALUE
           $ibm_power_hmc_log.info("#{self.class}##{__method__} #{elems[:type]} Missing LPAR UUID.  Escalating to full refresh for EMS: [#{ems.name}], id: [#{ems.id}].")
           target_collection << ems
         else

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -27,6 +27,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
     )
     new_targets = []
 
+    ems       = ems_event.ext_management_system
     raw_event = ems_event.full_data
 
     case ems_event.event_type
@@ -42,7 +43,8 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
         # This may be used to perform quick property REST API calls to the HMC
         # instead of querying the full LPAR data.
         if elems[:uuid].eql?(NO_UUID_VALUE)
-          new_targets << ems_event.ext_management_system
+          $ibm_power_hmc_log.info("#{self.class}##{__method__} #{elems[:type]} Missing LPAR UUID.  Escalating to full refresh for EMS: [#{ems.name}], id: [#{ems.id}].")
+          target_collection << ems
         else
           new_targets << {:assoc => :vms, :ems_ref => elems[:uuid]}
         end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -12,11 +12,22 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
         [[:hosts, {:ems_ref => '977848c8-3bed-360a-c9d2-ae4b7e46b5d1'}]]
       )
     end
-    it "LogicalPartition" do
-      assert_event_triggers_target(
-        "test_data/logical_partition_long_url.xml",
-        [[:vms, {:ems_ref => '74CC38E2-C6DD-4B03-A0C6-088F7882EF0E'}]]
-      )
+    context "LogicalPartition" do
+      it "targets the logical partition" do
+        assert_event_triggers_target(
+          "test_data/logical_partition_long_url.xml",
+          [[:vms, {:ems_ref => '74CC38E2-C6DD-4B03-A0C6-088F7882EF0E'}]]
+        )
+      end
+
+      context "with a missing LPAR UUID" do
+        it "targets the whole EMS" do
+          ems_event      = create_ems_event("test_data/logical_partition_invalid_uuid.xml")
+          parsed_targets = described_class.new(ems_event).parse
+
+          expect(parsed_targets).to eq([@ems])
+        end
+      end
     end
     it "VirtualIOServer" do
       assert_event_triggers_target(

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/logical_partition_invalid_uuid.xml
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/logical_partition_invalid_uuid.xml
@@ -1,0 +1,26 @@
+<feed>
+    <entry>
+        <id>1afb3833-8a85-369f-977a-bb8741b1a15a</id>
+        <title>Event</title>
+        <published>2022-02-02T15:05:12.772Z</published>
+        <link rel="SELF" href="https://te.st:12443/rest/api/uom/Event/1afb3833-8a85-369f-977a-bb8741b1a15a"/>
+        <author>
+            <name>IBM Power Systems Management Console</name>
+        </author>
+        <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-83524495</etag:etag>
+        <content type="application/vnd.ibm.powervm.uom+xml; type=Event">
+            <Event:Event xmlns:Event="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_6_0">
+    <Metadata>
+        <Atom>
+            <AtomID>1afb3833-8a85-369f-977a-bb8741b1a15a</AtomID>
+            <AtomCreated>1639561179310</AtomCreated>
+        </Atom>
+    </Metadata>
+    <EventType kb="ROR" kxe="false">ADD_URI</EventType>
+    <EventID kb="ROR" kxe="false">1639561179310</EventID>
+    <EventData kxe="false" kb="ROR">https://te.st:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/88888888-8888-8888-8888-888888888888</EventData>
+    <EventDetail kxe="false" kb="ROR">Other</EventDetail>
+</Event:Event>
+        </content>
+    </entry>
+</feed>


### PR DESCRIPTION
The HMC uses `88888888-8888-8888-8888-888888888888` to indicate an unassigned LPAR UUID. This is an error state, but we've seen it occur in a test environment so I'm adding a special case for it to trigger a full ems refresh.