### PR TITLE
Parse the event url with Regex not split

### DIFF
--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -28,6 +28,15 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
           expect(parsed_targets).to eq([@ems])
         end
       end
+
+      context "with an invalid EventData url" do
+        it "returns an empty target set" do
+          ems_event      = create_ems_event("test_data/logical_partition_invalid_event_data.xml")
+          parsed_targets = described_class.new(ems_event).parse
+
+          expect(parsed_targets).to be_empty
+        end
+      end
     end
     it "VirtualIOServer" do
       assert_event_triggers_target(

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/logical_partition_invalid_event_data.xml
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/logical_partition_invalid_event_data.xml
@@ -1,0 +1,26 @@
+<feed>
+    <entry>
+        <id>1afb3833-8a85-369f-977a-bb8741b1a15a</id>
+        <title>Event</title>
+        <published>2022-02-02T15:05:12.772Z</published>
+        <link rel="SELF" href="https://te.st:12443/rest/api/uom/Event/1afb3833-8a85-369f-977a-bb8741b1a15a"/>
+        <author>
+            <name>IBM Power Systems Management Console</name>
+        </author>
+        <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-83524495</etag:etag>
+        <content type="application/vnd.ibm.powervm.uom+xml; type=Event">
+            <Event:Event xmlns:Event="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_6_0">
+    <Metadata>
+        <Atom>
+            <AtomID>1afb3833-8a85-369f-977a-bb8741b1a15a</AtomID>
+            <AtomCreated>1639561179310</AtomCreated>
+        </Atom>
+    </Metadata>
+    <EventType kb="ROR" kxe="false">ADD_URI</EventType>
+    <EventID kb="ROR" kxe="false">1639561179310</EventID>
+    <EventData kxe="false" kb="ROR">https://te.st:12443/rest/api/uom/ManagedSyste/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/</EventData>
+    <EventDetail kxe="false" kb="ROR">Other</EventDetail>
+</Event:Event>
+        </content>
+    </entry>
+</feed>


### PR DESCRIPTION
This isn't the greatest regular expression of all time :D but it passes the specs.

The URLs for events that we get from the specs are:
```
https://te.st:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualSwitch/74CC38E2-C6DD-4B03-A0C6-088F7882EF0E
https://coophmc2:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedMemoryPool/557f7755-a4dc-30de-816d-387f42dd8fd3
https://te.st:12443/rest/api/uom/ManagedSystem/977848c8-3bed-360a-c9d2-ae4b7e46b5d1
https://te.st:12443/rest/api/uom/UserTask/1d43a4a6-903c-46f8-865d-a356559bb17f
https://te.st:12443/rest/api/uom/Cluster/c1e50c27-888c-3c4d-8d4a-53a3768ea250
https://coophmc2:12443/rest/api/uom/ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37/SharedProcessorPool/27aae064-2855-39a0-b4e6-e3c9b5572036
https://te.st:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/VirtualNetwork/74CC38E2-C6DD-4B03-A0C6-088F7882EF0E
https://te.st:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/74CC38E2-C6DD-4B03-A0C6-088F7882EF0E
```

Critically we have to handle the optional `ManagedSystem/d47a585d-eaa8-3a54-b4dc-93346276ea37` at the start of the url path, but if that is the whole path then we need it to match on type/uuid not manager_uuid

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
