### PR TITLE
Fix event parsing

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser.rb
@@ -21,7 +21,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser
     when "MODIFY_URI", "ADD_URI", "DELETE_URI" # Damien: INVALID_URI?
       $ibm_power_hmc_log.info("#{self.class}##{__method__} #{ems_event.event_type} #{ems_event.full_data}")
       elems = raw_event[:data]
-        .match(%r{/rest/api/uom/(?:ManagedSystem/(?<manager_uuid>[^/]+)/)?(?<type>[^/]+)/(?<uuid>[^/]+)$})
+        .match(%r{/rest/api/uom/(?:ManagedSystem/(?<manager_uuid>[^/]+)/)?(?<type>[^/]+)/(?<uuid>[^/]+)})
         &.named_captures || {}
       case elems["type"]
       when "ManagedSystem"

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/event_target_parser_spec.rb
@@ -29,6 +29,15 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::EventTargetParser do
         end
       end
 
+      context "with a missing LPAR UUID and LogicalPartitionProfile included in path" do
+        it "targets the whole EMS" do
+          ems_event      = create_ems_event("test_data/logical_partition_profile_invalid_uuid.xml")
+          parsed_targets = described_class.new(ems_event).parse
+
+          expect(parsed_targets).to eq([@ems])
+        end
+      end
+
       context "with an invalid EventData url" do
         it "returns an empty target set" do
           ems_event      = create_ems_event("test_data/logical_partition_invalid_event_data.xml")

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/logical_partition_profile_invalid_uuid.xml
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/test_data/logical_partition_profile_invalid_uuid.xml
@@ -1,0 +1,26 @@
+<feed>
+    <entry>
+        <id>1afb3833-8a85-369f-977a-bb8741b1a15a</id>
+        <title>Event</title>
+        <published>2022-02-02T15:05:12.772Z</published>
+        <link rel="SELF" href="https://te.st:12443/rest/api/uom/Event/1afb3833-8a85-369f-977a-bb8741b1a15a"/>
+        <author>
+            <name>IBM Power Systems Management Console</name>
+        </author>
+        <etag:etag xmlns:etag="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/">-83524495</etag:etag>
+        <content type="application/vnd.ibm.powervm.uom+xml; type=Event">
+            <Event:Event xmlns:Event="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns="http://www.ibm.com/xmlns/systems/power/firmware/uom/mc/2012_10/" xmlns:ns2="http://www.w3.org/XML/1998/namespace/k2" schemaVersion="V1_6_0">
+    <Metadata>
+        <Atom>
+            <AtomID>1afb3833-8a85-369f-977a-bb8741b1a15a</AtomID>
+            <AtomCreated>1639561179310</AtomCreated>
+        </Atom>
+    </Metadata>
+    <EventType kb="ROR" kxe="false">ADD_URI</EventType>
+    <EventID kb="ROR" kxe="false">1639561179310</EventID>
+    <EventData kxe="false" kb="ROR">https://te.st:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/88888888-8888-8888-8888-888888888888/LogicalPartitionProfile/123abc45-6789-0123-45de-67fa890bc123</EventData>
+    <EventDetail kxe="false" kb="ROR">Other</EventDetail>
+</Event:Event>
+        </content>
+    </entry>
+</feed>


### PR DESCRIPTION
Follow up to #164 (and #167).

When testing #164 I noticed the LPAR delete event URL also included `LogicalPartition` information, which prevented the event target parser from coming up with a target. For example:
```
https://te.st:12443/rest/api/uom/ManagedSystem/e4acf909-6d0b-3c03-b75a-4d8495e5fc49/LogicalPartition/88888888-8888-8888-8888-888888888888/LogicalPartitionProfile/123abc45-6789-0123-45de-67fa890bc123
```