### PR TITLE
Move secrets calls into the factory methods

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -5,21 +5,26 @@ FactoryBot.define do
           :parent  => :ems_infra
 
   factory :ems_ibm_power_hmc_infra_with_authentication, :parent => :ems_ibm_power_hmc_infra do
-    username = Rails.application.secrets.ibm_power_hmc[:username]
-    password = Rails.application.secrets.ibm_power_hmc[:password]
-    hostname = Rails.application.secrets.ibm_power_hmc[:hostname]
-
     zone do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
       zone
     end
 
     endpoints do
-      [FactoryBot.create(:endpoint, :role => "default", :hostname => hostname, :port => 12_443)]
+      [
+        FactoryBot.create(:endpoint,
+          :role     => "default",
+          :hostname => Rails.application.secrets.ibm_power_hmc[:hostname],
+          :port     => 12_443
+        )
+      ]
     end
 
     after(:create) do |ems|
-      ems.authentications << FactoryBot.create(:authentication, :userid => username, :password => password)
+      ems.authentications << FactoryBot.create(:authentication,
+        :userid   => Rails.application.secrets.ibm_power_hmc[:username],
+        :password => Rails.application.secrets.ibm_power_hmc[:password]
+      )
     end
   end
 end


### PR DESCRIPTION
@agrare Please review.

In core, these are causing warnings during specs, because when the factory is loaded these are referencing secrets. This moves them out of a setup-time scope into a run-time scope.

Before:

```
$ be rspec spec/models/miq_alert_spec.rb
...
** Using session_store: ActionDispatch::Session::MemoryStore
** ManageIQ master, codename: Tal
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from block (2 levels) in <main> at /Users/jfrey/.gem/ruby/3.3.7/bundler/gems/manageiq-providers-ibm_power_hmc-b3f270a76e8c/spec/factories/ext_management_system.rb:8)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from block (2 levels) in <main> at /Users/jfrey/.gem/ruby/3.3.7/bundler/gems/manageiq-providers-ibm_power_hmc-b3f270a76e8c/spec/factories/ext_management_system.rb:9)
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from block (2 levels) in <main> at /Users/jfrey/.gem/ruby/3.3.7/bundler/gems/manageiq-providers-ibm_power_hmc-b3f270a76e8c/spec/factories/ext_management_system.rb:10)

Randomized with seed 23133
```

After:

```
be rspec spec/models/miq_alert_spec.rb
...
** Using session_store: ActionDispatch::Session::MemoryStore
** ManageIQ master, codename: Tal

Randomized with seed 57264
```