### PR TITLE
Fix virtual_delegate deprecation in virtual attributes 8.0

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
   include ManageIQ::Providers::IbmPowerHmc::InfraManager::MetricsCaptureMixin
   include Reconfigure
 
-  virtual_delegate :hmc_managed, :to => :host, :prefix => true, :allow_nil => true, :type => :boolean
+  virtual_attribute :host_hmc_managed, :boolean, :through => :host, :source => :hmc_managed
 
   supports :capture
 


### PR DESCRIPTION
Fixes this warning with virtual attributes 8.0:

```
DEPRECATION WARNING: virtual_delegate is deprecated in favor of virtual_attribute. Change to: ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm.virtual_attribute :host_hmc_managed, :boolean, :through => :host, :source => :hmc_managed (called from <class:Vm> at /home/runner/work/manageiq-cross_repo-tests/manageiq-cross_repo-tests/repos/ManageIQ/manageiq@192522a58ceddf3e285b3227bac996f50091b2f5/vendor/bundle/ruby/3.3.0/bundler/gems/manageiq-providers-ibm_power_hmc-be5362f51ccf/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb:5)
...
```

Note, rails 8/virtual attributes was upgraded in https://github.com/ManageIQ/manageiq/pull/23699, resolving this issue: https://github.com/ManageIQ/manageiq/issues/23670

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
