### PR TITLE
Block VM Suspend Operation

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -10,6 +10,8 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
     _("Host is not HMC-managed") unless host_hmc_managed
   end
 
+  supports_not :suspend
+
   supports :rename do
     _("Host is not HMC-managed") unless host_hmc_managed
   end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
@@ -38,7 +38,7 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar do
       expect(vm.vm_powered_on?).to be true
       expect(vm.supports?(:start)).to be false
       expect(vm.supports?(:stop)).to (be true), "unsupported reason: #{vm.unsupported_reason(:stop)}"
-      expect(vm.supports?(:suspend)).to (be true), "unsupported reason: #{vm.unsupported_reason(:suspend)}"
+      expect(vm.supports?(:suspend)).to be false
       vm.raw_power_state = "not activated"
       expect(vm.vm_powered_on?).to be false
       expect(vm.supports?(:start)).to (be true), "unsupported reason: #{vm.unsupported_reason(:start)}"


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->
VMs running on Power systems do not support the Suspend operation. Previously, ManageIQ allowed users to perform this operation, but it is now blocked. Screenshot after fixing Suspend operation.
<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->
<img width="2112" height="835" alt="Block Suspend Operation" src="https://github.com/user-attachments/assets/42fb40f2-3b58-42eb-8b1f-964c8c5c30bb" />

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
@miq-bot add-label bug