### PR TITLE
Add an option to select a parent IbmPowerVC

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager.rb
@@ -5,6 +5,12 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
   supports :native_console
   supports :provisioning
 
+  belongs_to :parent_manager,
+             :class_name  => "ManageIQ::Providers::IbmPowerVc::CloudManager",
+             :foreign_key => :parent_ems_id,
+             :inverse_of  => :ibm_power_hmcs,
+             :autosave    => true
+
   has_many :hosts_advanced_settings, :through => :hosts, :source => :advanced_settings
   has_many :media_repositories, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :iso_images, :through => :media_repositories
@@ -24,8 +30,17 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
               :name                   => 'authentications.default.valid',
               :skipSubmit             => true,
               :isRequired             => true,
-              :validationDependencies => %w[type zone_id],
+              :validationDependencies => %w[type zone_id parent_ems_id],
               :fields                 => [
+                {
+                  :component   => "select",
+                  :id          => "parent_ems_id",
+                  :name        => "parent_ems_id",
+                  :label       => _("IBM PowerVC Cloud Provider"),
+                  :isClearable => true,
+                  :simpleValue => true,
+                  :options     => parent_ems_id_options
+                },
                 {
                   :component    => "select",
                   :id           => "endpoints.default.security_protocol",
@@ -87,6 +102,19 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager < ManageIQ::Providers::Infr
         }
       ]
     }
+  end
+
+  private_class_method def self.parent_ems_id_options
+    t = ManageIQ::Providers::IbmPowerVc::CloudManager
+    Rbac
+      .filtered(t.order(t.arel_table[:name].lower))
+      .pluck(:name, :id)
+      .map do |name, id|
+        {
+          :label => name,
+          :value => id.to_s,
+        }
+      end
   end
 
   def self.verify_credentials(args)

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager_spec.rb
@@ -19,6 +19,168 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager do
     end
   end
 
+  describe ".parent_ems_id_options" do
+    it "returns an empty array when no PowerVC managers exist" do
+      expect(described_class.send(:parent_ems_id_options)).to eq([])
+    end
+
+    context "with PowerVC managers" do
+      let!(:power_vc_1) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC 1") }
+      let!(:power_vc_2) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC 2") }
+      let!(:power_vc_3) { FactoryBot.create(:ems_ibm_power_vc, :name => "powerVC 3") }
+
+      it "returns formatted options with label and value" do
+        options = described_class.send(:parent_ems_id_options)
+        expect(options).to match_array(
+          [
+            {:label => power_vc_1.name, :value => power_vc_1.id.to_s},
+            {:label => power_vc_2.name, :value => power_vc_2.id.to_s},
+            {:label => power_vc_3.name, :value => power_vc_3.id.to_s}
+          ]
+        )
+      end
+
+      it "converts id to string in value field" do
+        options = described_class.send(:parent_ems_id_options)
+        option = options.find { |opt| opt[:label] == "PowerVC 1" }
+        expect(option[:value]).to eq(power_vc_1.id.to_s)
+      end
+
+      it "includes all PowerVC managers" do
+        options = described_class.send(:parent_ems_id_options)
+        values = options.map { |opt| opt[:value] }
+        expect(values).to contain_exactly(
+          power_vc_1.id.to_s,
+          power_vc_2.id.to_s,
+          power_vc_3.id.to_s
+        )
+      end
+    end
+  end
+
+  describe ".create_from_params" do
+    let(:zone) { EvmSpecHelper.create_guid_miq_server_zone.last }
+    let(:params) { {"name" => "HMC Manager", "zone" => zone} }
+    let(:endpoints) { [{"role" => "default", "hostname" => "hmc.example.com", "port" => 443, "security_protocol" => "ssl-with-validation"}] }
+    let(:authentications) { [{"authtype" => "default", "userid" => "hscroot", "password" => "secret"}] }
+
+    context "with a parent_ems_id for an IbmPowerVc parent" do
+      let!(:power_vc) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC Manager") }
+      let(:params_with_parent) { params.merge("parent_ems_id" => power_vc.id) }
+
+      it "creates the EMS with the parent relationship" do
+        ems = described_class.create_from_params(params_with_parent, endpoints, authentications)
+        expect(ems.name).to eq(params["name"])
+        expect(ems.parent_manager).to eq(power_vc)
+        expect(ems.parent_ems_id).to eq(power_vc.id)
+      end
+
+      it "creates the endpoints correctly" do
+        ems = described_class.create_from_params(params_with_parent, endpoints, authentications)
+        expect(ems.endpoints.count).to eq(1)
+        expect(ems.endpoints.find_by(:role => "default")).to have_attributes(
+          :hostname          => "hmc.example.com",
+          :port              => 443,
+          :security_protocol => "ssl-with-validation"
+        )
+      end
+
+      it "creates the authentications correctly" do
+        ems = described_class.create_from_params(params_with_parent, endpoints, authentications)
+        expect(ems.authentications.count).to eq(1)
+        expect(ems.authentications.find_by(:authtype => "default")).to have_attributes(
+          :userid => "hscroot"
+        )
+      end
+    end
+
+    context "without a parent_ems_id" do
+      it "creates the EMS without a parent relationship" do
+        ems = described_class.create_from_params(params, endpoints, authentications)
+        expect(ems.name).to eq(params["name"])
+        expect(ems.parent_manager).to be_nil
+        expect(ems.parent_ems_id).to be_nil
+      end
+    end
+  end
+
+  describe "#edit_with_params" do
+    let(:zone) { EvmSpecHelper.create_guid_miq_server_zone.last }
+    let!(:ems) do
+      FactoryBot.create(:ems_ibm_power_hmc_infra, :name => "HMC Manager", :zone => zone).tap do |ems|
+        ems.authentications << FactoryBot.create(:authentication, :authtype => "default", :userid => "hscroot", :password => "secret")
+      end
+    end
+    let(:params) { {"name" => ems.name, "zone" => ems.zone} }
+    let(:endpoints) { [{"role" => "default", "hostname" => ems.hostname, "port" => ems.port}] }
+    let(:authentications) { [{"authtype" => "default", "userid" => "hscroot"}] }
+
+    context "setting a parent_ems_id" do
+      let!(:power_vc) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC Manager") }
+      let(:params_with_parent) { params.merge("parent_ems_id" => power_vc.id) }
+
+      it "sets the parent relationship" do
+        expect(ems.parent_manager).to be_nil
+
+        ems.edit_with_params(params_with_parent, endpoints, authentications)
+        ems.reload
+
+        expect(ems.parent_manager).to eq(power_vc)
+        expect(ems.parent_ems_id).to eq(power_vc.id)
+      end
+    end
+
+    context "clearing a parent_ems_id" do
+      let!(:power_vc) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC Manager") }
+
+      before do
+        ems.update!(:parent_ems_id => power_vc.id)
+      end
+
+      it "clears the parent relationship when parent_ems_id is nil" do
+        expect(ems.parent_manager).to eq(power_vc)
+
+        params_without_parent = params.merge("parent_ems_id" => nil)
+        ems.edit_with_params(params_without_parent, endpoints, authentications)
+        ems.reload
+
+        expect(ems.parent_manager).to be_nil
+        expect(ems.parent_ems_id).to be_nil
+      end
+
+      it "clears the parent relationship when parent_ems_id is empty string" do
+        expect(ems.parent_manager).to eq(power_vc)
+
+        params_without_parent = params.merge("parent_ems_id" => "")
+        ems.edit_with_params(params_without_parent, endpoints, authentications)
+        ems.reload
+
+        expect(ems.parent_manager).to be_nil
+        expect(ems.parent_ems_id).to be_nil
+      end
+    end
+
+    context "changing parent_ems_id" do
+      let!(:power_vc_1) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC 1") }
+      let!(:power_vc_2) { FactoryBot.create(:ems_ibm_power_vc, :name => "PowerVC 2") }
+
+      before do
+        ems.update!(:parent_ems_id => power_vc_1.id)
+      end
+
+      it "changes from one parent to another" do
+        expect(ems.parent_manager).to eq(power_vc_1)
+
+        params_with_new_parent = params.merge("parent_ems_id" => power_vc_2.id)
+        ems.edit_with_params(params_with_new_parent, endpoints, authentications)
+        ems.reload
+
+        expect(ems.parent_manager).to eq(power_vc_2)
+        expect(ems.parent_ems_id).to eq(power_vc_2.id)
+      end
+    end
+  end
+
   describe "#parse_hmc_version" do
     let(:ems) { FactoryBot.create(:ems_ibm_power_hmc_infra) }
 


### PR DESCRIPTION
Allow the user to select a parent IbmPowerVc CloudManager

Adding new provider, new field with nothing selected:
<img width="1605" height="573" alt="Screenshot From 2026-03-16 09-43-25" src="https://github.com/user-attachments/assets/e7af2edb-b91f-437d-bf38-d8dc9bd6a4e6" />

Dropdown with 1 Power VC provider:
<img width="1605" height="573" alt="Screenshot From 2026-03-16 09-43-33" src="https://github.com/user-attachments/assets/e85eb986-b93f-4998-a1cb-51fea1a11ae4" />

Co-depends:
- [x] https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/148

Cross-repo-test:
* https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/1039

https://github.com/ManageIQ/manageiq/issues/23755
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
