### PR TITLE
Move refresh checks after each refresh

### DIFF
--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/refresher_spec.rb
@@ -17,18 +17,18 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Refresher do
       2.times do
         full_refresh(ems)
         ems.reload
-      end
 
-      assert_ems
-      assert_specific_host
-      assert_specific_switch
-      assert_specific_lan
-      assert_specific_vios
-      assert_specific_lpar
-      assert_specific_template
-      assert_specific_resource_pool_cpu
-      assert_specific_resource_pool_mem
-      assert_specific_storage
+        assert_ems
+        assert_specific_host
+        assert_specific_switch
+        assert_specific_lan
+        assert_specific_vios
+        assert_specific_lpar
+        assert_specific_template
+        assert_specific_resource_pool_cpu
+        assert_specific_resource_pool_mem
+        assert_specific_storage
+      end
     end
   end
 


### PR DESCRIPTION
The point of running the refresh twice is to ensure that nothing changes when doing the same refresh twice.

Only checking counts and inventory after running twice defeats this purpose.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
