### PR TITLE
[Fix] fix for the guest restart and shutdown from ManageIQ UI

### DIFF
--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -21,11 +21,19 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
   end
 
   supports :shutdown_guest do
-    unsupported_reason(:control)
+    if !vm_powered_on?
+      _("The VM is not powered on")
+    else
+      unsupported_reason(:control)
+    end
   end
 
   supports :reboot_guest do
-    unsupported_reason(:control)
+    if !vm_powered_on?
+      _("The VM is not powered on")
+    else
+      unsupported_reason(:control)
+    end
   end
 
   supports :native_console do

--- a/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb
@@ -20,6 +20,14 @@ class ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm < ManageIQ::Providers::
     _("Host is not HMC-managed") unless host_hmc_managed
   end
 
+  supports :shutdown_guest do
+    unsupported_reason(:control)
+  end
+
+  supports :reboot_guest do
+    unsupported_reason(:control)
+  end
+
   supports :native_console do
     unsupported_reason(:action)
   end

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
@@ -45,13 +45,21 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar do
       expect(vm.supports?(:stop)).to be false
       expect(vm.supports?(:suspend)).to be false
     end
-    it "supports guest operations" do
+    it "supports guest operations when powered on" do
       host.advanced_settings.create!(:name => "hmc_managed", :value => "true")
       vm.raw_power_state = "running"
-      expect(vm.supports?(:shutdown_guest)).to (be true), "unsupported reason: #{vm.unsupported_reason(:shutdown_guest)}"
-      expect(vm.supports?(:reboot_guest)).to (be true), "unsupported reason: #{vm.unsupported_reason(:reboot_guest)}"
+      expect(vm.vm_powered_on?).to be_truthy
+      expect(vm.supports?(:shutdown_guest)).to be_truthy, "unsupported reason: #{vm.unsupported_reason(:shutdown_guest)}"
+      expect(vm.supports?(:reboot_guest)).to be_truthy, "unsupported reason: #{vm.unsupported_reason(:reboot_guest)}"
     end
-    it "does not support guest operations" do
+    it "does not support guest operations when powered off" do
+      host.advanced_settings.create!(:name => "hmc_managed", :value => "true")
+      vm.raw_power_state = "not activated"
+      expect(vm.vm_powered_on?).to be_falsey
+      expect(vm.supports?(:shutdown_guest)).to be_falsey
+      expect(vm.supports?(:reboot_guest)).to be_falsey
+    end
+    it "does not support guest operations when host not HMC-managed" do
       host.advanced_settings.create!(:name => "hmc_managed", :value => "false")
       vm.raw_power_state = "running"
       expect(vm.supports?(:shutdown_guest)).to be false

--- a/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb
@@ -45,6 +45,18 @@ describe ManageIQ::Providers::IbmPowerHmc::InfraManager::Lpar do
       expect(vm.supports?(:stop)).to be false
       expect(vm.supports?(:suspend)).to be false
     end
+    it "supports guest operations" do
+      host.advanced_settings.create!(:name => "hmc_managed", :value => "true")
+      vm.raw_power_state = "running"
+      expect(vm.supports?(:shutdown_guest)).to (be true), "unsupported reason: #{vm.unsupported_reason(:shutdown_guest)}"
+      expect(vm.supports?(:reboot_guest)).to (be true), "unsupported reason: #{vm.unsupported_reason(:reboot_guest)}"
+    end
+    it "does not support guest operations" do
+      host.advanced_settings.create!(:name => "hmc_managed", :value => "false")
+      vm.raw_power_state = "running"
+      expect(vm.supports?(:shutdown_guest)).to be false
+      expect(vm.supports?(:reboot_guest)).to be false
+    end
     it "does not support power operations" do
       host.advanced_settings.create!(:name => "hmc_managed", :value => "false")
       vm.raw_power_state = "running"


### PR DESCRIPTION
# Add support declarations for guest operations on IBM Power HMC VMs

## What This PR Does

This PR fixes the "Shutdown Guest action does not apply to selected items" error that occurs when attempting to perform guest operations (Shutdown Guest, Reboot Guest) on IBM Power HMC virtual machines through the ManageIQ UI.

## Problem

The IBM Power HMC provider had implemented the underlying methods for guest operations (`raw_shutdown_guest`, `raw_reboot_guest`) but was missing the required `supports` declarations. ManageIQ's UI validates feature support before executing operations by calling `records_support_feature?()`, which checks if all selected VMs support the requested feature. Without these declarations, the validation failed and prevented the operations from executing.

## Solution

Added `supports` declarations for `:shutdown_guest` and `:reboot_guest` features in the `ManageIQ::Providers::IbmPowerHmc::InfraManager::Vm` class. These declarations delegate to the existing `:control` support check, which validates that the host is HMC-managed.

## Changes Made

### 1. Added Support Declarations
**File**: `app/models/manageiq/providers/ibm_power_hmc/infra_manager/vm.rb`

Added:
```ruby
supports :shutdown_guest do
  unsupported_reason(:control)
end

supports :reboot_guest do
  unsupported_reason(:control)
end
```

### 2. Added Spec Tests
**File**: `spec/models/manageiq/providers/ibm_power_hmc/infra_manager/lpar_spec.rb`

Added two new test cases:
- **"supports guest operations"** - Verifies `:shutdown_guest` and `:reboot_guest` are supported when host is HMC-managed
- **"does not support guest operations"** - Verifies these operations are NOT supported when host is not HMC-managed

## Testing

- Added RSpec tests that verify support declarations work correctly
- Verified that "Shutdown Guest" and "Reboot Guest" buttons are now functional in the UI
- Confirmed that operations are properly restricted to HMC-managed hosts
- Tested that the underlying API calls (`poweroff` with appropriate parameters) are executed correctly

## API Call Flow

1. **UI** → `vm_infra_controller.rb` → VmCommon module
2. **Validation** → `ci_processing.rb` checks `supports?(:shutdown_guest)` 
3. **Core** → `vm/operations/guest.rb` calls `raw_shutdown_guest()`
4. **Provider** → `vm.rb` calls `poweroff("operation" => "osshutdown")`
5. **LPAR** → `lpar.rb` calls `connection.poweroff_lpar()`
6. **SDK** → REST API: `POST /rest/api/uom/LogicalPartition/{uuid}/do/PowerOff` with `{"operation": "osshutdown"}`

---

@miq-bot add-label bug
@miq-bot add-label enhancement



Before Fix
<img width="2098" height="848" alt="image" src="https://github.com/user-attachments/assets/d4432cbc-06ba-48c9-9818-a298334b677b" />

After Fix
<img width="3178" height="2056" alt="image" src="https://github.com/user-attachments/assets/e5c530f5-4f32-4993-a245-7f27e4e84e37" />
